### PR TITLE
Bitextor.faz

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,6 @@ For Bitextor 7 and Git master branch:
         Hieu Hoang
         hieuhoang@gmail.com
         University of Edinburgh
+				Faheem Kirefu
+				fkirefu@ed.ac.uk
+				University of Edinburgh

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -926,6 +926,7 @@ else:
             OUTPUT.append("{dir}/{l1}-{l2}.raw.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
         if "deduped" in config and config["deduped"]:
             OUTPUT.append("{dir}/{l1}-{l2}.deduped.tmx.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
+            OUTPUT.append("{dir}/{l1}-{l2}.deduped.txt.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
         else:
             OUTPUT.append("{dir}/{l1}-{l2}.not-deduped.tmx.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
     else:
@@ -1650,13 +1651,14 @@ rule tmx:
     shell:
         "xzcat -T 0 -f {input} | {PROFILING} {BITEXTOR}/bitextor-buildTMX.py --lang1 {LANG1} --lang2 {LANG2} -c url1,url2,seg1,seg2,hunalign{DEFERREDFIELDS}{BICLEANEROPTION}{ELRCFIELDS} | xz -T 0 > {output}"
 
-rule deduped_tmx:
+rule deduped_tmx_txt:
     input:
         "{permanentdir}".format(permanentdir=config["permanentDir"])+"/{l1}-{l2}.sent.xz"
     output:
-        "{permanentdir}".format(permanentdir=config["permanentDir"])+"/{l1}-{l2}.deduped.tmx.xz"
+        tmx="{permanentdir}".format(permanentdir=config["permanentDir"])+"/{l1}-{l2}.deduped.tmx.xz",
+        txt="{permanentdir}".format(permanentdir=config["permanentDir"])+"/{l1}-{l2}.deduped.txt.xz"
     shell:
-        "xzcat -T 0 -f {input} | LC_ALL=C sort -t$'\t' {BICLEANER_SORT} -T {TMPDIR} --compress-program=gzip | {PROFILING} {BITEXTOR}/bitextor-buildTMX-dedup.py --lang1 {LANG1} --lang2 {LANG2} -c url1,url2,seg1,seg2,hunalign{BICLEANEROPTION}{ELRCFIELDS}{DEFERREDFIELDS} | xz -T 0 > {output}"
+        "xzcat -T 0 -f {input} | LC_ALL=C sort -t$'\t' {BICLEANER_SORT} -T {TMPDIR} --compress-program=gzip | {PROFILING} {BITEXTOR}/bitextor-buildTMX-dedup.py --lang1 {LANG1} --lang2 {LANG2} -c url1,url2,seg1,seg2,hunalign{BICLEANEROPTION}{ELRCFIELDS}{DEFERREDFIELDS} -d {output.txt} | xz -T 0 > -d {output.tmx}"
 
 rule mt_parallel_data:
     input:

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -764,7 +764,7 @@ InitConcatLogicLink(domainKey2Hosts)
 if len(WARCFILES) != 0:
     #If WARC files are provided (through --WARCFiles option), add path to WARC file(s) to the domain WARCDOMAIN
     domainKey2Hosts = AddWARCFiles(domainKey2Hosts, WARCFILES)
-    #If only one WARC is provided, creates a symbolic link to it 
+    #If only one WARC is provided, creates a symbolic link to it
     InitWARCFilesConcatLogic(domainKey2Hosts, WARCFILES)
 
 # print("domainKey2Hosts", domainKey2Hosts)
@@ -896,6 +896,8 @@ else:
             OUTPUT.append("{dir}/{l1}-{l2}.not-deduped.tmx.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
     else:
         OUTPUT.append("{dir}/{l1}-{l2}.sent.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
+
+print(OUTPUT, domainKey2Hosts)
 
 rule all:
     input:
@@ -1115,7 +1117,7 @@ rule warc2preprocessXzlang:
         directory('{dir}/w2p-xzlang/xzlang')
     priority: 8
     shell:
-        'mkdir -p {wildcards.dir}/w2p-xzlang/xzlang;' 
+        'mkdir -p {wildcards.dir}/w2p-xzlang/xzlang;'
         #By removing the checkpoint every time, we ensure that rule split_warc will be re-run every time, which allows to resume the pipeline if this step breaks
         '{PROFILING} nice ionice -c 3 {BITEXTOR}/bitextor-warc2preprocess.py {boilerpipeCleaning} --xzlang --output-dir {wildcards.dir}/w2p-xzlang/xzlang --input {input} {usepdfextract} {PARSER}; '
 
@@ -1132,7 +1134,7 @@ rule warc2preprocess:
         url='{dir}/w2p/url.xz'
     priority: 8
     shell:
-        'mkdir -p {wildcards.dir}/w2p;' 
+        'mkdir -p {wildcards.dir}/w2p;'
         #By removing the checkpoint every time, we ensure that rule split_warc will be re-run every time, which allows to resume the pipeline if this step breaks
         '{PROFILING} nice ionice -c 3 {BITEXTOR}/bitextor-warc2preprocess.py {boilerpipeCleaning} --output-dir {wildcards.dir}/w2p --lang1 {LANG1} --lang2 {LANG2} --input {input} {usepdfextract} {PARSER}; '
         'if [ "{boilerpipeCleaning}" == "" ]; then ln -sfn {output.html} {output.deboil}; fi'
@@ -1483,9 +1485,9 @@ rule bicleaner:
     shell:
         'slang=$(egrep "source_lang" {BICLEANER_CONFIG} | cut -d " " -f 2); '
         'if [ "$slang" == "{LANG1}" ]; then '
-        '  xzcat -T 0 -f {input.segclean} | {PROFILING} python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} | xz -T 0 > {output}; '
+        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | cut -f3,4 | {PROFILING} {BITEXTOR}/preprocess/bin/cache parallel -k --block 5M --pipe python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
         'else '
-        '  xzcat -T 0 -f {input.segclean} | awk \' BEGIN {{FS="\t"; OFS="\t"}} {{ print $1 "\t" $2 "\t" $4 "\t" $3 "\t" $5}}\' | {PROFILING} python3  {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG}  | awk \' BEGIN {{FS="\t"; OFS=","}} {{ print $1 "\t" $2 "\t" $4 "\t" $3 "\t" $5 "\t" $6}}\' | xz -T 0 > {output}; '
+        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | awk \' BEGIN {{FS="\t"; OFS="\t"}} {{ print $4 "\t" $3 }}\' | {PROFILING} {BITEXTOR}/preprocess/bin/cache parallel -k --block 5M --pipe python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
         'fi'
 
 rule bicleanerfilter:

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -164,6 +164,11 @@ def ValidateArgs(config):
 
            'mgiza': {'type': 'string'},
 
+           'parallelBlock' : {'type': 'integer'},
+           'parallelMemfree' : {'type': 'integer'},
+           'parallelTranslate' : {'type': 'boolean'},
+           'parallelBicleaner' : {'type': 'boolean'},
+
             }
 
     if ("httrack" in config and config["httrack"] == True) or ("crawler" in config and config["crawler"] == 'httrack'):
@@ -486,6 +491,34 @@ if "bifixerOptions" in config:
     BIFIXEROPTIONS=config["bifixerOptions"]
 else:
     BIFIXEROPTIONS="--aggressive_dedup"
+
+
+############ MEMORY AND PARALLEL PROCESSING OPTIONS OPTIONS ############
+
+
+# Set options for parallel command (for translation and bicleaner)
+if "parallelBlock" in config and config["parallelBlock"]:
+    PARALLEL_BLOCK=config["parallelBlock"]
+else:
+    PARALLEL_BLOCK=5000000
+
+if "parallelMemfree" in config and config["parallelMemfree"]:
+    PARALLEL_MEMFREE=config["parallelMemfree"]
+else:
+    PARALLEL_MEMFREE=20000000
+
+if "parallelTranslate" in config and config["parallelTranslate"]:
+    PARALLEL_TRANS_CMD="parallel -k --block {PARALLEL_BLOCK} --memfree {PARALLEL_MEMFREE} --pipe".format(PARALLEL_BLOCK=PARALLEL_BLOCK, PARALLEL_MEMFREE=PARALLEL_MEMFREE)
+else:
+    PARALLEL_TRANS_CMD=""
+
+
+if "parallelBicleaner" in config and config["parallelBicleaner"]:
+    PARALLEL_BICLEANER_CMD="parallel -k --block {PARALLEL_BLOCK} --memfree {PARALLEL_MEMFREE} --pipe".format(PARALLEL_BLOCK=PARALLEL_BLOCK, PARALLEL_MEMFREE=PARALLEL_MEMFREE)
+else:
+    PARALLEL_BICLEANER_CMD=""
+
+
 
 #========================= MAPPING URLS AND OUTPUT FILES =========================#
 
@@ -1286,59 +1319,102 @@ rule docaling_deduped:
     shell:
         "xzcat -T 0 {input}  | cut -d$'\t' -f 2 | sort -T {TMPDIR} --compress-program=gzip | uniq | xz -c -T 0 > {output}"
 
+
 rule docaling_translate_nmt:
     input:
-        source = "{dir}/{prefix}/extracted.deduped.xz"
+        source = "{dir}/{lang}.extracted.xz"
         ,
         configFile = "{dir}/config.json".format(dir=transient)
         ,
         report = "{transient}/nmt-dir/evaluation/report".format(transient=transient)
 
     output:
-        temp("{dir}/{prefix}.nmt.extracted.deduped.translated.xz")
+        "{dir}/{lang}.nmt.extracted.translated.xz",
 
     priority: 40
 
     shell:
-        'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
+        'paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir ) | xz -c -T 0 > {output}; '
+        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
 
 rule docaling_translate_smt:
     input:
-        source = "{dir}/{prefix}.extracted.deduped.xz"
+        source = "{dir}/{lang}.extracted.xz"
         ,
         report = "{transient}/smt-dir/steps/1/REPORTING_report.1.DONE".format(transient=transient)
 
     output:
-        temp("{dir}/{prefix}.smt.extracted.deduped.translated.xz")
-
+        "{dir}/{lang}.smt.extracted.translated.xz",
+    threads: 8
     params:
         smtDir = "{0}/smt-dir".format(config["transientDir"])
 
     shell:
-        'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi'
-
+        'paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} ) | xz -c -T 0 > {output}; '
+        'if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi; '
 
 rule docaling_custom_translate:
     input:
-        "{prefix}.extracted.deduped.xz",
+        "{dir}/{lang}.extracted.xz",
     output:
-        temp("{prefix}.customMT.extracted.deduped.translated.xz")
+        "{dir}/{lang}.customMT.extracted.translated.xz",
+    threads: 8
     shell:
-        'xzcat -T 0 {input} | {MT_COMMAND} | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
+        'paste <(xzcat -T 0 {input} | cut -f1 ) <(xzcat -T 0 {input} | cut -f2 | {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {MT_COMMAND} ) | xz -c -T 0 > {output}; '
+        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
 
-
-rule docaling_substitute_translated:
-    input:
-        extracted="{prefix}.extracted.xz",
-        deduped="{prefix}.extracted.deduped.xz",
-        translated="{prefix}.{mttype}.extracted.deduped.translated.xz"
-    output:
-        "{prefix}.{mttype}.extracted.translated.xz"
-    shell:
-        'xzcat -T 0 {input.extracted} | {PROFILING} python3 {BITEXTOR}/document-aligner/substitute_translated.py --deduplicated {input.deduped} --translated {input.translated} | xz -c -T 0 > {output}'
+# rule docaling_translate_nmt:
+#     input:
+#         source = "{dir}/{prefix}/extracted.deduped.xz"
+#         ,
+#         configFile = "{dir}/config.json".format(dir=transient)
+#         ,
+#         report = "{transient}/nmt-dir/evaluation/report".format(transient=transient)
+#
+#     output:
+#         temp("{dir}/{prefix}.nmt.extracted.deduped.translated.xz")
+#
+#     priority: 40
+#
+#     shell:
+#         'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir | xz -c -T 0 > {output}; '
+#         'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
+#
+# rule docaling_translate_smt:
+#     input:
+#         source = "{dir}/{prefix}.extracted.deduped.xz"
+#         ,
+#         report = "{transient}/smt-dir/steps/1/REPORTING_report.1.DONE".format(transient=transient)
+#
+#     output:
+#         temp("{dir}/{prefix}.smt.extracted.deduped.translated.xz")
+#
+#     params:
+#         smtDir = "{0}/smt-dir".format(config["transientDir"])
+#
+#     shell:
+#         'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} | xz -c -T 0 > {output}; '
+#         'if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi'
+#
+# rule docaling_custom_translate:
+#     input:
+#         "{prefix}.extracted.deduped.xz",
+#     output:
+#         temp("{prefix}.customMT.extracted.deduped.translated.xz")
+#     shell:
+#         'xzcat -T 0 {input} | {MT_COMMAND} | xz -c -T 0 > {output}; '
+#         'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
+#
+#
+# rule docaling_substitute_translated:
+#     input:
+#         extracted="{prefix}.extracted.xz",
+#         deduped="{prefix}.extracted.deduped.xz",
+#         translated="{prefix}.{mttype}.extracted.deduped.translated.xz"
+#     output:
+#         "{prefix}.{mttype}.extracted.translated.xz"
+#     shell:
+#         'xzcat -T 0 {input.extracted} | {PROFILING} python3 {BITEXTOR}/document-aligner/substitute_translated.py --deduplicated {input.deduped} --translated {input.translated} | xz -c -T 0 > {output}'
 
 rule docaling_matches:
     input:
@@ -1482,13 +1558,14 @@ rule bicleaner:
         model="{model}".format(model=BICLEANER_CONFIG)
     output:
         "{prefix}.bicleaner.scores.xz"
+    threads: 8
     shell:
         'slang=$(egrep "source_lang" {BICLEANER_CONFIG} | cut -d " " -f 2); '
         'if [ "$slang" == "{LANG1}" ]; then '
-        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | cut -f3,4 | {PROFILING} {BITEXTOR}/preprocess/bin/cache parallel -k --block 5M --pipe python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
+        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | cut -f3,4 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_BICLEANER_CMD} python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
         'else '
-        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | awk \' BEGIN {{FS="\t"; OFS="\t"}} {{ print $4 "\t" $3 }}\' | {PROFILING} {BITEXTOR}/preprocess/bin/cache parallel -k --block 5M --pipe python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
-        'fi'
+        '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | awk \' BEGIN {{FS="\t"; OFS="\t"}} {{ print $4 "\t" $3 }}\' | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_BICLEANER_CMD} python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
+        'fi; '
 
 # combine bicleanerfilter and elrc into one rule, and using awk instead
 rule bicleaner_filter_elrc:

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -598,6 +598,7 @@ def ExcludeHosts(hosts, excludeHosts):
             hosts.remove(host)
     print("AFTER hosts", len(hosts), len(hostsCopy))
 
+
 def GetHostsFromLangstat(langstat_path, lang1, lang2, threshold, exclude_path):
     print("langstat_path", langstat_path, file=sys.stderr)
     l12 = [lang1.lower(), lang2.lower()]
@@ -929,8 +930,6 @@ else:
             OUTPUT.append("{dir}/{l1}-{l2}.not-deduped.tmx.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
     else:
         OUTPUT.append("{dir}/{l1}-{l2}.sent.xz".format(dir=permanent, l1=LANG1, l2=LANG2))
-
-print(OUTPUT, domainKey2Hosts)
 
 rule all:
     input:
@@ -1299,7 +1298,7 @@ rule aligndocumentsBitextor:
 
 ################# MT-BASED DOCUMENT ALIGNMENT #################
 
-rule docaling_extracted:
+rule docalign_extracted:
     input:
         text='{dir}'+'/{PPROC}/plain_text.xz'.format( PPROC=PPROC),
         lang='{dir}'+'/{PPROC}/lang.xz'.format( PPROC=PPROC),
@@ -1309,18 +1308,26 @@ rule docaling_extracted:
         "{dir}/docalign/"+"{l2}.extracted.xz".format(l2=LANG2)
     shell:
         'mkdir -p {wildcards.dir}/docalign; '
-        '{PROFILING} {BITEXTOR}/document-aligner/utils/extract_lett.py -x --langs {LANG1},{LANG2} --plaintextfile {input.text} --urlfile {input.url} --langfile {input.lang} --splitter1 "{SENTTOK1}" --splitter2 "{SENTTOK2}" --prune_type "words" --prune 80 --output_dir {wildcards.dir}/docalign'
+        'langs=$( xzcat {input.lang} | LC_ALL=C sort -u | xargs ); '
 
-rule docaling_deduped:
-    input:
-        "{dir}/{lang}.extracted.xz"
-    output:
-        temp("{dir}/{lang}.extracted.deduped.xz")
-    shell:
-        "xzcat -T 0 {input}  | cut -d$'\t' -f 2 | sort -T {TMPDIR} --compress-program=gzip | uniq | xz -c -T 0 > {output}"
+        'if [[ ${{langs[@]}} =~ {LANG1} ]] && [[ ${{langs[@]}} =~ {LANG2} ]]; then '
+        '  {PROFILING} {BITEXTOR}/document-aligner/utils/extract_lett.py -x --langs {LANG1},{LANG2} --plaintextfile {input.text} --urlfile {input.url} --langfile {input.lang} --splitter1 "{SENTTOK1}" --splitter2 "{SENTTOK2}" --prune_type "words" --prune 80 --output_dir {wildcards.dir}/docalign ; '
+        'else '
+        '  touch {dir}/empty && xz {dir}/empty && mv {dir}/empty.xz {output[0]} ; '
+        '  touch {dir}/empty && xz {dir}/empty && mv {dir}/empty.xz {output[1]} ; '
+        '  >&2 echo "EARLY STOPPING: Discontinuing domain $(basename {wildcards.dir}), as {LANG1} or {LANG2} not found" ; '
+        'fi; '
 
+# rule docalign_deduped:
+#     input:
+#         "{dir}/{lang}.extracted.xz"
+#     output:
+#         temp("{dir}/{lang}.extracted.deduped.xz")
+#     shell:
+#         "xzcat -T 0 {input}  | cut -d$'\t' -f 2 | sort -T {TMPDIR} --compress-program=gzip | uniq | xz -c -T 0 > {output}"
+#
 
-rule docaling_translate_nmt:
+rule docalign_translate_nmt:
     input:
         source = "{dir}/{lang}.extracted.xz"
         ,
@@ -1334,10 +1341,15 @@ rule docaling_translate_nmt:
     priority: 40
 
     shell:
-        'paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir ) | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
+        'if [ $(wc {input.source} -c | cut -f1 -d\' \' ) -le 32 ]; then '
+        '  touch {dir}/empty && xz {dir}/empty && mv {dir}/empty.xz {output} ; ; '
+        'else '
+        '  paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir ) | xz -c -T 0 > {output}; '
+        '  if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
+        'fi ; '
 
-rule docaling_translate_smt:
+
+rule docalign_translate_smt:
     input:
         source = "{dir}/{lang}.extracted.xz"
         ,
@@ -1350,20 +1362,32 @@ rule docaling_translate_smt:
         smtDir = "{0}/smt-dir".format(config["transientDir"])
 
     shell:
-        'paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} ) | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi; '
+        'if [ $(wc {input.source} -c | cut -f1 -d\' \' ) -le 32 ]; then '
+        '  touch {dir}/empty && xz {dir}/empty && mv {dir}/empty.xz {output} ; '
+        'else '
+        '  paste <(xzcat -T 0 {input.source} | cut -f1 ) <(xzcat -T 0 {input.source} | cut -f2 | {PROFILING} {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} ) | xz -c -T 0 > {output}; '
+        '  if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi; '
+        'fi ; '
 
-rule docaling_custom_translate:
+
+
+rule docalign_custom_translate:
     input:
         "{dir}/{lang}.extracted.xz",
     output:
         "{dir}/{lang}.customMT.extracted.translated.xz",
     threads: 8
     shell:
-        'paste <(xzcat -T 0 {input} | cut -f1 ) <(xzcat -T 0 {input} | cut -f2 | {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {MT_COMMAND} ) | xz -c -T 0 > {output}; '
-        'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
+        'if [ $(wc {input} -c | cut -f1 -d\' \' ) -le 32 ]; then '
+        '  touch {dir}/empty && xz {dir}/empty && mv {dir}/empty.xz {output} ; '
+        'else '
+        '   paste <(xzcat -T 0 {input} | cut -f1 ) <(xzcat -T 0 {input} | cut -f2 | {BITEXTOR}/preprocess/bin/cache {PARALLEL_TRANS_CMD} {MT_COMMAND} ) | xz -c -T 0 > {output}; '
+        '   if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi; '
+        'fi ; '
 
-# rule docaling_translate_nmt:
+
+
+# rule docalign_translate_nmt:
 #     input:
 #         source = "{dir}/{prefix}/extracted.deduped.xz"
 #         ,
@@ -1380,7 +1404,7 @@ rule docaling_custom_translate:
 #         'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/nmt/translate.sh {input.configFile} {wildcards.dir} {permanent}/nmt-dir | xz -c -T 0 > {output}; '
 #         'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
 #
-# rule docaling_translate_smt:
+# rule docalign_translate_smt:
 #     input:
 #         source = "{dir}/{prefix}.extracted.deduped.xz"
 #         ,
@@ -1396,7 +1420,7 @@ rule docaling_custom_translate:
 #         'xzcat -T 0 {input.source} | {PROFILING} {BITEXTOR}/snakemake/translate-smt.sh {LANG1} {MOSESDIR} {params.smtDir} | xz -c -T 0 > {output}; '
 #         'if [ "$(xzcat -T 0 {input.source} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input.source} and {output} should have the same number of lines"; exit 2; fi'
 #
-# rule docaling_custom_translate:
+# rule docalign_custom_translate:
 #     input:
 #         "{prefix}.extracted.deduped.xz",
 #     output:
@@ -1406,7 +1430,7 @@ rule docaling_custom_translate:
 #         'if [ "$(xzcat -T 0 {input} | wc -l)" -ne "$(xzcat -T 0 {output} | wc -l)" ]; then >&2 echo "TRANSLATION ERROR (command {MT_COMMAND}): {input} and {output} should have the same number of lines"; exit 2; fi'
 #
 #
-# rule docaling_substitute_translated:
+# rule docalign_substitute_translated:
 #     input:
 #         extracted="{prefix}.extracted.xz",
 #         deduped="{prefix}.extracted.deduped.xz",
@@ -1416,7 +1440,7 @@ rule docaling_custom_translate:
 #     shell:
 #         'xzcat -T 0 {input.extracted} | {PROFILING} python3 {BITEXTOR}/document-aligner/substitute_translated.py --deduplicated {input.deduped} --translated {input.translated} | xz -c -T 0 > {output}'
 
-rule docaling_matches:
+rule docalign_matches:
     input:
         l1="{dir}/"+"{l1}".format(l1=LANG1)+".{mttype}.extracted.translated.xz",
         l2="{dir}/"+"{l2}.extracted.xz".format(l2=LANG2)

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1490,21 +1490,32 @@ rule bicleaner:
         '  paste <(xzcat -T 0 -f {input.segclean}) <(xzcat -T 0 -f {input.segclean} | awk \' BEGIN {{FS="\t"; OFS="\t"}} {{ print $4 "\t" $3 }}\' | {PROFILING} {BITEXTOR}/preprocess/bin/cache parallel -k --block 5M --pipe python3 {BITEXTOR}/bicleaner/bicleaner/bicleaner_classifier_lite.py -q --score_only --threshold {BICLEANER_THRESHOLD} - - {BICLEANER_CONFIG} ) | xz -T 0 > {output}; '
         'fi'
 
-rule bicleanerfilter:
+# combine bicleanerfilter and elrc into one rule, and using awk instead
+rule bicleaner_filter_elrc:
     input:
         "{prefix}.bicleaner.scores.xz"
     output:
-        "{prefix}.bicleaner.xz"
-    shell:
-        'xzcat -T 0 -f {input} | {PROFILING} {BITEXTOR}/bitextor-filterbicleaner.py --threshold {BICLEANER_THRESHOLD} | xz -T 0 > {output}'
-
-rule elrc:
-    input:
-        "{prefix}."+"{extension}".format(extension=BICLEANER)+".xz"
-    output:
         "{prefix}.elrc.xz"
     shell:
-        'xzcat -T 0 -f {input} | {PROFILING} {BITEXTOR}/bitextor-elrc-filtering.py -c "url1,url2,seg1,seg2,hunalign{DEFERREDFIELDS}{BICLEANEROPTION}" -s | xz -T 0 > {output}'
+        'xzcat -T 0 -f {input} | awk -F\'\t\' \'{{ if ($NF >= {BICLEANER_THRESHOLD}) {{ print $0 }} }}\' | {PROFILING} {BITEXTOR}/bitextor-elrc-filtering.py -c "url1,url2,seg1,seg2,hunalign{DEFERREDFIELDS}{BICLEANEROPTION}" -s | xz -T 0 > {output}'
+
+
+
+# rule bicleanerfilter:
+#     input:
+#         "{prefix}.bicleaner.scores.xz"
+#     output:
+#         "{prefix}.bicleaner.xz"
+#     shell:
+#         'xzcat -T 0 -f {input} | {PROFILING} {BITEXTOR}/bitextor-filterbicleaner.py --threshold {BICLEANER_THRESHOLD} | xz -T 0 > {output}'
+#
+# rule elrc:
+#     input:
+#         "{prefix}."+"{extension}".format(extension=BICLEANER)+".xz"
+#     output:
+#         "{prefix}.elrc.xz"
+#     shell:
+#         'xzcat -T 0 -f {input} | {PROFILING} {BITEXTOR}/bitextor-elrc-filtering.py -c "url1,url2,seg1,seg2,hunalign{DEFERREDFIELDS}{BICLEANEROPTION}" -s | xz -T 0 > {output}'
 
 rule raw:
     input:

--- a/snakemake/example/cluster.json
+++ b/snakemake/example/cluster.json
@@ -2,14 +2,15 @@
     "__default__" :
     {
         "gres": "",
-	"oversubscribe": ""
+        "oversubscribe": "",
+        "cpus-per-task": ""
     },
 
     "httrack_download" :
     {
         "oversubscribe": "-s"
     },
-    
+
     "docaling_translate_nmt" :
     {
         "gres": "--gres gpu:tesla:1"
@@ -24,15 +25,35 @@
     {
         "gres": "--gres gpu:tesla:1"
     },
-    
+
     "train_nmt":
     {
         "gres": "--gres gpu:tesla:1"
     },
-    
+
     "translate_test":
     {
         "gres": "--gres gpu:tesla:1"
-    }
+    },
+
+    "bicleaner":
+    {
+        "cpus-per-task": "--cpus-per-task 8"
+    },
+
+    "docaling_custom_translate":
+    {
+        "cpus-per-task": "--cpus-per-task 8"
+    },
+
+    "docaling_nmt_translate":
+    {
+        "cpus-per-task": "--cpus-per-task 8"
+    },
+
+    "docaling_smt_translate":
+    {
+        "cpus-per-task": "--cpus-per-task 8"
+    },
 
 }

--- a/snakemake/example/faheem/config.tester.yaml
+++ b/snakemake/example/faheem/config.tester.yaml
@@ -1,0 +1,44 @@
+bitextor: /fs/meili0/faheem/bitextor
+langstat: /home/s0565741/workspace/experiment/issues/paracrawl/langstat/langstats.all.gz
+langstatThreshold: 1000000
+# linkedHosts: ["/home/s0565741/workspace/experiment/paracrawl/v3/hu-en/permanent",
+#               "/home/s0565741/workspace/experiment/paracrawl/v3/fr-en/permanent",
+#               "/home/s0565741/workspace/experiment/paracrawl/v3/de-en/permanent",
+#               "/home/s0565741/workspace/experiment/paracrawl/v3/it-en/permanent",
+#               "/home/s0565741/workspace/experiment/paracrawl/v3/es-en/permanent"]
+linkedHostsAction: link #postCrawlExclude #remove
+
+langstatExcludeStrings: /home/s0565741/workspace/github/paracrawl/bitextor.malign.old/snakemake/langstat-exclude-strings
+excludeHostsFile: /home/s0565741/workspace/github/paracrawl/bitextor.malign.old/snakemake/exclude-hosts
+crawlerUserAgent: Mozilla/5.0 (compatible; Paracrawl; +http://statmt.org/paracrawl/robots.html)
+httrack: true
+
+temp: /raid0/tmp
+permanentDir: /fs/meili0/faheem/testing/permanent
+transientDir: /fs/meili0/faheem/testing/transient
+lang1: pl
+lang2: en
+crawlTimeLimit: 43200s
+crawlPageLimit: 100000
+
+#mosesDir: /home/s0565741/workspace/github/mosesdecoder
+LANG1Tokenizer: "/home/s0565741/workspace/github/paracrawl/bitextor.malign.old/preprocess/moses/tokenizer/tokenizer.perl -l pl -a -b -q"
+LANG2Tokenizer: "/home/s0565741/workspace/github/paracrawl/bitextor.malign.old/preprocess/moses/tokenizer/tokenizer.perl -l en -a -b -q"
+LANG1SentenceSplitter: "/home/s0565741/workspace/github/paracrawl/bitextor.malign.old/preprocess/moses/ems/support/split-sentences.perl -b -l pl"
+LANG2SentenceSplitter: "/home/s0565741/workspace/github/paracrawl/bitextor.malign.old/preprocess/moses/ems/support/split-sentences.perl -b -l en"
+deduped: true
+tmx: true
+storeRawCorpus: true
+elrc: true
+documentAligner: externalMT
+alignerCmd: "/fs/meili0/faheem/bitextor.malign/mt_models/serverNMT.sh pl en sigyn hretha"
+bleualign: true
+docAlignThreshold: 0.1
+bleuAlignThreshold: 0.2
+maxSizeWARC: 5000
+bicleaner: /home/s0565741/workspace/experiment/paracrawl/v3/bicleaner_models/en-pl/training.en-pl.yaml
+bicleanerThreshold: 0.7
+parallelBlock: 50000
+parallelMemfree: 20000000
+parallelTranslate: true
+parallelBicleaner: true


### PR DESCRIPTION
Hi,

I've submitted several changes

Added cache capabilities to bicleaner rules: 
- no longer computing score multiple times for same sentence pair
- bicleaner/bicleaner_classifier_lite.py also updated to output score_only

Added parallel capabilities to bicleaner and translate rules:

 - this is wrapped by cache.
- When running in cluster mode, cluster.json file must include a cpus-per-task parameter for parallel to work.
- new boolean config options: parallelTranslate, parallelBicleaner
- new integer config options: parallelBlock, parallelMemfree

Merged rules bicleaner filter and elrc to just one rule:

- replaced bitextor-filterbicleaner.py with an awk command

Added early stopping:

- rule docalign_extracted (no more docaling!) first checks whether lang1 and lang2 are both in the lang.xz file, and if not, creates empty output files.
- translation rules also check if input is non empty, otherwise automatically generate empty output
- this could be recursively implemented, bu hopefully a nicer solution will be found.

Changes to deduped_tmx rule:

- Now automatically generates the corresponding deduped txt.gz file, along with the tmx.


I have tested that the changed rules work for the different scenarios, but of course may have missed a test case.


Best wishes,

Faheem
