### PR TITLE
Test cases & bug fix for NGramIterator

### DIFF
--- a/document-aligner/CMakeLists.txt
+++ b/document-aligner/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.12)
 # Define a single cmake project
 project(document-aligner)
 
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wextra -Ofast")
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wextra -g ")
@@ -17,6 +19,7 @@ endif()
 # We need boost
 find_package(Boost 1.41.0 REQUIRED COMPONENTS
   program_options
+  unit_test_framework
 )
 
 find_package(ICU REQUIRED COMPONENTS
@@ -41,6 +44,7 @@ endif()
 # find *.h and *.cpp files
 file(GLOB dalign_cpp_headers ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h)
 file(GLOB dalign_cpp_cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+file(GLOB dalign_tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp)
 
 # Tool to score alignment between two sets of documents in the same language.
 add_executable(docalign docalign.cpp ${dalign_cpp_headers} ${dalign_cpp_cpp})
@@ -50,3 +54,8 @@ target_link_libraries(docalign ${Boost_LIBRARIES} preprocess_util)
 # Similar to coreutils join, but using line indices and works on gzipped files
 add_executable(docjoin docjoin.cpp ${dalign_cpp_headers} ${dalign_cpp_cpp})
 target_link_libraries(docjoin preprocess_util)
+
+add_executable(ngram_test tests/ngram_test.cpp ${dalign_cpp_headers} ${dalign_cpp_cpp})
+target_link_libraries(ngram_test ${Boost_LIBRARIES} preprocess_util)
+
+add_test(NAME ngram_test COMMAND ngram_test)

--- a/document-aligner/CMakeLists.txt
+++ b/document-aligner/CMakeLists.txt
@@ -57,5 +57,5 @@ target_link_libraries(docjoin preprocess_util)
 
 add_executable(ngram_test tests/ngram_test.cpp ${dalign_cpp_headers} ${dalign_cpp_cpp})
 target_link_libraries(ngram_test ${Boost_LIBRARIES} preprocess_util)
-
 add_test(NAME ngram_test COMMAND ngram_test)
+

--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -153,14 +153,14 @@ int main(int argc, char *argv[])
 	// Calculate the document frequency for terms. Starts a couple of threads
 	// that parse documents and keep a local hash table for counting. At the
 	// end these tables are merged into df.
-	unordered_map<uint64_t,size_t> df;
+	unordered_map<NGram,size_t> df;
 	size_t in_document_cnt, en_document_cnt, document_cnt;
 
 	{
 		mutex df_mutex;
 		blocking_queue<unique_ptr<Line>> queue(n_sample_threads * 128);
 		vector<thread> workers(start(n_sample_threads, [&queue, &df, &df_mutex, &ngram_size, &df_sample_rate]() {
-			unordered_map<uint64_t, size_t> local_df;
+			unordered_map<NGram, size_t> local_df;
 
 			while (true) {
 				unique_ptr<Line> line(queue.pop());
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 	// sample rate of higher than 1, your min_ngram_count should also be a
 	// multiple of sample rate + 1.
 	{
-		unordered_map<uint64_t, size_t> pruned_df;
+		unordered_map<NGram, size_t> pruned_df;
 		for (auto const &entry : df) {
 			if (entry.second < min_ngram_cnt)
 				continue;

--- a/document-aligner/src/document.cpp
+++ b/document-aligner/src/document.cpp
@@ -53,7 +53,7 @@ inline float tfidf(size_t tf, size_t dc, size_t df) {
  * across all documents. Only terms that are seen in this document and in the document frequency table are
  * counted. All other terms are ignored.
 */
-void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, unordered_map<uint64_t, size_t> const &df) {
+void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, unordered_map<NGram, size_t> const &df) {
 	document_ref.id = document.id;
 
 	document_ref.wordvec.clear();

--- a/document-aligner/src/document.h
+++ b/document-aligner/src/document.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "util/string_piece.hh"
+#include "ngram.h"
 #include <istream>
 #include <unordered_map>
 #include <vector>
@@ -7,7 +8,7 @@
 namespace bitextor {
 
 struct WordScore {
-	uint64_t hash; // Same as NGram::hash
+	NGram hash;
 	float tfidf;
 };
 
@@ -16,7 +17,7 @@ struct Document {
 	size_t id;
 	
 	// ngram frequency in document
-	std::unordered_map<uint64_t, size_t> vocab;
+	std::unordered_map<NGram, size_t> vocab;
 };
 
 struct DocumentRef {
@@ -34,7 +35,7 @@ std::ostream &operator<<(std::ostream &stream, Document const &document);
 
 std::ostream &operator<<(std::ostream &stream, DocumentRef const &ref);
 
-void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, std::unordered_map<uint64_t, size_t> const &df);
+void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, std::unordered_map<NGram, size_t> const &df);
 
 float calculate_alignment(DocumentRef const &left, DocumentRef const &right);
 

--- a/document-aligner/src/ngram.cpp
+++ b/document-aligner/src/ngram.cpp
@@ -27,6 +27,8 @@ void NGramIter::init() {
 	// Some documents are just too short
 	if (!token_it_)
 		end_ = true;
+
+	increment();
 }
 
 void NGramIter::increment() {

--- a/document-aligner/src/ngram.h
+++ b/document-aligner/src/ngram.h
@@ -5,6 +5,8 @@
 
 namespace bitextor {
 
+typedef uint64_t NGram;
+
 class NGramIter : public boost::iterator_facade<NGramIter, const uint64_t, boost::forward_traversal_tag> {
 public:
 	NGramIter();
@@ -27,7 +29,7 @@ private:
 	size_t pos_;
 	bool end_;
 	std::vector<uint64_t> buffer_;
-	uint64_t ngram_hash_;
+	NGram ngram_hash_;
 
 	void init();
 	void increment();
@@ -36,7 +38,7 @@ private:
 		return token_it_ == other.token_it_ && end_ == other.end_;
 	}
 
-	inline const uint64_t &dereference() const {
+	inline const NGram &dereference() const {
 		UTIL_THROW_IF(end_, util::OutOfTokens, "We already reached end");
 		return ngram_hash_;
 	}

--- a/document-aligner/tests/ngram_test.cpp
+++ b/document-aligner/tests/ngram_test.cpp
@@ -1,0 +1,36 @@
+#define BOOST_TEST_MODULE example
+#include <vector>
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+#include "../src/ngram.h"
+#include "../src/murmur_hash.h"
+
+using namespace std;
+using namespace bitextor;
+
+NGram make_ngram(vector<string> const &words)
+{
+	uint64_t hash = 0;
+
+	for (string const &word : words)
+		hash = MurmurHashCombine(MurmurHashNative(word.data(), word.size(), 0), hash);
+
+	return hash;
+}
+
+BOOST_AUTO_TEST_CASE(test_ngram_it_1)
+{
+	string document = "Hello this is a test";
+	
+	vector<NGram> ngrams;
+	for (NGramIter iter(StringPiece(document.data(), document.size()), 3); iter; ++iter)
+		ngrams.push_back(*iter);
+
+	vector<NGram> expected{
+		make_ngram({"Hello", "this", "is"}),
+		make_ngram({"this", "is", "a"}),
+		make_ngram({"is", "a", "test"})
+	};
+
+	BOOST_TEST(ngrams == expected, boost::test_tools::per_element());
+}

--- a/document-aligner/tests/ngram_test.cpp
+++ b/document-aligner/tests/ngram_test.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE example
+#define BOOST_TEST_MODULE ngram_iter
 #include <vector>
 #include <iostream>
 #include <boost/test/unit_test.hpp>
@@ -18,7 +18,7 @@ NGram make_ngram(vector<string> const &words)
 	return hash;
 }
 
-BOOST_AUTO_TEST_CASE(test_ngram_it_1)
+BOOST_AUTO_TEST_CASE(test_trigram)
 {
 	string document = "Hello this is a test";
 	
@@ -33,4 +33,30 @@ BOOST_AUTO_TEST_CASE(test_ngram_it_1)
 	};
 
 	BOOST_TEST(ngrams == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(test_equal_length)
+{
+	string document = "Hello this is a test";
+	
+	vector<NGram> ngrams;
+	for (NGramIter iter(StringPiece(document.data(), document.size()), 5); iter; ++iter)
+		ngrams.push_back(*iter);
+
+	vector<NGram> expected{
+		make_ngram({"Hello", "this", "is", "a", "test"})
+	};
+
+	BOOST_TEST(ngrams == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(test_not_enough_tokens)
+{
+	string document = "Not enough";
+	
+	vector<NGram> ngrams;
+	for (NGramIter iter(StringPiece(document.data(), document.size()), 5); iter; ++iter)
+		ngrams.push_back(*iter);
+
+	BOOST_TEST(ngrams.size() == 0);
 }


### PR DESCRIPTION
The first token yielded by the NGramIterator was bogus as it wasn't fully initialised. This patch fixes that and adds proper test cases instead of the ad hoc code I was using and didn't catch it.