### PR TITLE
Docalign performance

### DIFF
--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
 
 	unsigned int n_load_threads = n_threads;
 
-	unsigned int n_read_threads = min(n_threads, min(max(n_threads / 4u, 1u), 4u)); // really no use to have more than 4 threads decode
+	unsigned int n_read_threads = n_threads;
 
 	unsigned int n_score_threads = n_threads;
 	
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
 
 	// Start reading the other set of documents we match against and do the matching.
 	{
-		blocking_queue<unique_ptr<Line>> read_queue(n_read_threads * 128);
+		blocking_queue<unique_ptr<Line>> read_queue(n_read_threads * 1024);
 
 		blocking_queue<unique_ptr<DocumentRef>> score_queue(n_score_threads * 256);
 

--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -35,6 +35,8 @@ struct DocumentNGramScore {
 	float tfidf;
 };
 
+constexpr size_t QUEUE_SIZE_PER_THREAD = 32;
+
 constexpr size_t BATCH_SIZE = 512;
 
 /**
@@ -91,6 +93,39 @@ size_t queue_lines(util::FilePiece &fin, blocking_queue<unique_ptr<Line>> &queue
 }
 
 size_t queue_lines(std::string const &path, blocking_queue<unique_ptr<Line>> &queue, size_t skip_rate = 1)
+{
+	util::FilePiece fin(path.c_str());
+	return queue_lines(fin, queue, skip_rate);
+}
+
+size_t queue_lines(util::FilePiece &fin, blocking_queue<unique_ptr<vector<Line>>> &queue, size_t skip_rate = 1)
+{
+	size_t document_count = 0;
+
+	auto it = fin.begin();
+
+	while (it != fin.end()) {
+		unique_ptr<vector<Line>> line_batch(new vector<Line>());
+		line_batch->reserve(BATCH_SIZE);
+
+		for (size_t i = 0; i < BATCH_SIZE; ++i) {
+			if (document_count++ % skip_rate == 0)
+				line_batch->push_back({
+					.str = string(it->data(), it->size()),
+					.n = document_count
+				});
+
+			if (++it == fin.end())
+				break;
+		}
+
+		queue.push(move(line_batch));
+	}
+
+	return document_count;
+}
+
+size_t queue_lines(std::string const &path, blocking_queue<unique_ptr<vector<Line>>> &queue, size_t skip_rate = 1)
 {
 	util::FilePiece fin(path.c_str());
 	return queue_lines(fin, queue, skip_rate);
@@ -159,6 +194,11 @@ int main(int argc, char *argv[])
 
 	unsigned int n_load_threads = n_threads;
 
+	// Note: I've tried many heuristics for the number of reading threads, but
+	// my conclusion was that I either have too few and the scoring threads are
+	// waiting, or the queue is filled and the reading threads are blocking
+	// anyway. On desktop (macOS) just using maximum threads everywhere was
+	// always the fastest.
 	unsigned int n_read_threads = n_threads;
 
 	unsigned int n_score_threads = n_threads;
@@ -171,20 +211,22 @@ int main(int argc, char *argv[])
 
 	{
 		mutex df_mutex;
-		blocking_queue<unique_ptr<Line>> queue(n_sample_threads * 128);
+		blocking_queue<unique_ptr<vector<Line>>> queue(n_sample_threads * QUEUE_SIZE_PER_THREAD);
 		vector<thread> workers(start(n_sample_threads, [&queue, &df, &df_mutex, &ngram_size, &df_sample_rate]() {
 			unordered_map<NGram, size_t> local_df;
 
 			while (true) {
-				unique_ptr<Line> line(queue.pop());
+				unique_ptr<vector<Line>> line_batch(queue.pop());
 
-				if (!line)
+				if (!line_batch)
 					break;
 
-				Document document;
-				ReadDocument(line->str, document, ngram_size);
-				for (auto const &entry : document.vocab)
-					local_df[entry.first] += 1; // Count once every document
+				for (Line const &line : *line_batch) {
+					Document document;
+					ReadDocument(line.str, document, ngram_size);
+					for (auto const &entry : document.vocab)
+						local_df[entry.first] += 1; // Count once every document
+				}
 			}
 
 			// Merge the local DF into the global one. Multiply by df_sample_rate
@@ -241,31 +283,33 @@ int main(int argc, char *argv[])
 	{
 		mutex ref_index_mutex;
 
-		blocking_queue<unique_ptr<Line>> queue(n_load_threads * 128);
+		blocking_queue<unique_ptr<vector<Line>>> queue(n_load_threads * QUEUE_SIZE_PER_THREAD);
 		vector<thread> workers(start(n_load_threads, [&queue, &ref_index, &ref_index_mutex, &df, &document_cnt, &ngram_size]() {
 			unordered_map<NGram, vector<DocumentNGramScore>> local_ref_index;
 
 			while (true) {
-				unique_ptr<Line> line(queue.pop());
+				unique_ptr<vector<Line>> line_batch(queue.pop());
 
-				if (!line)
+				if (!line_batch)
 					break;
 
-				Document doc{.id = line->n};
-				ReadDocument(line->str, doc, ngram_size);
+				for (Line const &line : *line_batch) {
+					Document doc{.id = line.n};
+					ReadDocument(line.str, doc, ngram_size);
 
-				// Note that each worker writes to a different line in the refs
-				// vector and the vector has been initialized with enough lines
-				// so there should be no concurrency issue.
-				// DF is accessed read-only. N starts counting at 1.
-				DocumentRef ref;
-				calculate_tfidf(doc, ref, document_cnt, df);
+					// Note that each worker writes to a different line in the refs
+					// vector and the vector has been initialized with enough lines
+					// so there should be no concurrency issue.
+					// DF is accessed read-only. N starts counting at 1.
+					DocumentRef ref;
+					calculate_tfidf(doc, ref, document_cnt, df);
 
-				for (auto const &entry : ref.wordvec) {
-					local_ref_index[entry.hash].push_back(DocumentNGramScore{
-						.doc_id = line->n,
-						.tfidf = entry.tfidf
-					});
+					for (auto const &entry : ref.wordvec) {
+						local_ref_index[entry.hash].push_back(DocumentNGramScore{
+							.doc_id = line.n,
+							.tfidf = entry.tfidf
+						});
+					}
 				}
 			}
 
@@ -299,28 +343,24 @@ int main(int argc, char *argv[])
 
 	// Start reading the other set of documents we match against and do the matching.
 	{
-		blocking_queue<unique_ptr<Line>> read_queue(n_read_threads * 1024);
+		blocking_queue<unique_ptr<vector<Line>>> read_queue(n_read_threads * QUEUE_SIZE_PER_THREAD);
 
-		blocking_queue<unique_ptr<vector<DocumentRef>>> score_queue(n_score_threads * 1024);
+		blocking_queue<unique_ptr<vector<DocumentRef>>> score_queue(n_score_threads * QUEUE_SIZE_PER_THREAD);
 
 		vector<thread> read_workers(start(n_read_threads, [&read_queue, &score_queue, &document_cnt, &df, &ngram_size]() {
-			bool good = true;
+			while (true) {
+				unique_ptr<vector<Line>> line_batch(read_queue.pop());
 
-			while (good) {
+				// Empty pointer is poison
+				if (!line_batch)
+					break;
+
 				unique_ptr<vector<DocumentRef>> ref_batch(new vector<DocumentRef>());
-				ref_batch->reserve(BATCH_SIZE);
+				ref_batch->reserve(line_batch->size());
 			
-				for (size_t i = 0; i < BATCH_SIZE; ++i) {
-					unique_ptr<Line> line(read_queue.pop());
-
-					// Empty pointer is poison
-					if (!line) {
-						good = false;
-						break;
-					}
-
-					Document doc{.id = line->n, .vocab = {}};
-					ReadDocument(line->str, doc, ngram_size);
+				for (Line const &line : *line_batch) {
+					Document doc{.id = line.n};
+					ReadDocument(line.str, doc, ngram_size);
 
 					ref_batch->emplace_back();
 					calculate_tfidf(doc, ref_batch->back(), document_cnt, df);

--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -76,28 +76,6 @@ void print_score(float score, size_t left_id, size_t right_id)
 	     << '\n';
 }
 
-size_t queue_lines(util::FilePiece &fin, blocking_queue<unique_ptr<Line>> &queue, size_t skip_rate = 1)
-{
-	size_t document_count = 0;
-	for (StringPiece line : fin) {
-		if (document_count++ % skip_rate)
-			continue;
-
-		queue.push(unique_ptr<Line>(new Line{
-			.str = string(line.data(), line.size()),
-			.n = document_count
-		}));
-	}
-
-	return document_count;
-}
-
-size_t queue_lines(std::string const &path, blocking_queue<unique_ptr<Line>> &queue, size_t skip_rate = 1)
-{
-	util::FilePiece fin(path.c_str());
-	return queue_lines(fin, queue, skip_rate);
-}
-
 size_t queue_lines(util::FilePiece &fin, blocking_queue<unique_ptr<vector<Line>>> &queue, size_t skip_rate = 1)
 {
 	size_t document_count = 0;

--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -294,7 +294,7 @@ int main(int argc, char *argv[])
 					break;
 
 				for (Line const &line : *line_batch) {
-					Document doc{.id = line.n};
+					Document doc{.id = line.n, .vocab = {}};
 					ReadDocument(line.str, doc, ngram_size);
 
 					// Note that each worker writes to a different line in the refs
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
 				ref_batch->reserve(line_batch->size());
 			
 				for (Line const &line : *line_batch) {
-					Document doc{.id = line.n};
+					Document doc{.id = line.n, .vocab = {}};
 					ReadDocument(line.str, doc, ngram_size);
 
 					ref_batch->emplace_back();

--- a/document-aligner/docalign.cpp
+++ b/document-aligner/docalign.cpp
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
 				if (!line)
 					break;
 
-				Document doc{.id = line->n, .vocab = {}};
+				Document doc{.id = line->n};
 				ReadDocument(line->str, doc, ngram_size);
 
 				// Note that each worker writes to a different line in the refs

--- a/document-aligner/src/document.cpp
+++ b/document-aligner/src/document.cpp
@@ -16,6 +16,8 @@ void ReadDocument(const StringPiece &encoded, Document &document, size_t ngram_s
 {
 	std::string body;
 	base64_decode(encoded, body);
+
+	document.vocab.clear();
 	for (NGramIter ngram_it(body, ngram_size); ngram_it; ++ngram_it)
 		document.vocab[*ngram_it] += 1;
 }
@@ -42,15 +44,12 @@ void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t
 		// How often does the term occur in the whole dataset?
 		auto it = df.find(entry.first);
 
-		// Match Python implementation behaviour
+		// Skip words that are not in the document frequency map entirely.
+		// (Matches Python implementation)
 		if (it == df.end())
 			continue;
 	
-		// If we can't find it (e.g. because we didn't really read the whole
-		// dataset) we just assume one: just this document.
-		size_t term_df = it == df.end() ? 1 : it->second;
-	
-		float document_tfidf = tfidf(entry.second, document_count, term_df);
+		float document_tfidf = tfidf(entry.second, document_count, it->second);
 		
 		// Keep track of the squared sum of all values for L2 normalisation
 		total_tfidf_l2 += document_tfidf * document_tfidf;

--- a/document-aligner/src/document.cpp
+++ b/document-aligner/src/document.cpp
@@ -19,29 +19,6 @@ void ReadDocument(const StringPiece &encoded, Document &document, size_t ngram_s
 	for (NGramIter ngram_it(body, ngram_size); ngram_it; ++ngram_it)
 		document.vocab[*ngram_it] += 1;
 }
-
-/**
- * Ostream helper for printing documents, for debugging
- */
-ostream &operator<<(ostream &stream, Document const &document)
-{
-	stream << "--- Document ---\n" << document.id << "\n";
-
-	for (auto const &entry : document.vocab)
-		stream << entry.first << ": " << entry.second << "\n";
-
-	return stream << "--- end ---";
-}
-	
-ostream &operator<<(ostream &stream, DocumentRef const &document)
-{
-	stream << "--- Document Ref ---\n" << document.id << "\n";
-
-	for (auto const &entry : document.wordvec)
-		stream << entry.hash << ": " << entry.tfidf << "\n";
-
-	return stream << "--- end ---";
-}
 	
 inline float tfidf(size_t tf, size_t dc, size_t df) {
 	// Note: Matches tf_smooth setting 14 (2 for TF and 2 for IDF) of the python implementation
@@ -84,44 +61,10 @@ void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t
 		});
 	}
 	
-	// Sort wordvec, which is assumed by calculate_alignment
-	sort(document_ref.wordvec.begin(),
-		 document_ref.wordvec.end(),
-		 [] (WordScore const &lft, WordScore const &rgt) {
-		return lft.hash < rgt.hash;
-	});
-	
 	// Normalize
-	
 	total_tfidf_l2 = sqrt(total_tfidf_l2);
 	for (auto &entry : document_ref.wordvec)
 		entry.tfidf /= total_tfidf_l2;
-}
-
-/**
- * Dot product of two documents (of their ngram frequency really)
- */
-float calculate_alignment(DocumentRef const &left, DocumentRef const &right) {
-	float score = 0;
-	
-	auto lit = left.wordvec.cbegin(),
-		 rit = right.wordvec.cbegin(),
-		 lend = left.wordvec.cend(),
-		 rend = right.wordvec.cend();
-	
-	while (lit != lend && rit != rend) {
-		if (lit->hash < rit->hash)
-			++lit;
-		else if (rit->hash < lit->hash)
-			++rit;
-		else {
-			score += lit->tfidf * rit->tfidf;
-			++lit;
-			++rit;
-		}
-	}
-	
-	return score;
 }
 
 } // namespace bitextor

--- a/document-aligner/src/document.h
+++ b/document-aligner/src/document.h
@@ -31,12 +31,6 @@ struct DocumentRef {
 // Assumes base64 encoded still.
 void ReadDocument(const StringPiece &encoded, Document &to, size_t ngram_size);
 
-std::ostream &operator<<(std::ostream &stream, Document const &document);
-
-std::ostream &operator<<(std::ostream &stream, DocumentRef const &ref);
-
 void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, std::unordered_map<NGram, size_t> const &df);
-
-float calculate_alignment(DocumentRef const &left, DocumentRef const &right);
 
 } // namespace bitextor

--- a/document-aligner/src/ngram.cpp
+++ b/document-aligner/src/ngram.cpp
@@ -41,9 +41,9 @@ void NGramIter::increment() {
 	buffer_[pos_ % ngram_size_] = MurmurHashNative(token_it_->data(), token_it_->size(), 0);
 	
 	// Create hash from combining past N word hashes
-	ngram_hash_ = 0;
+	ngram_.hash = 0;
 	for (long offset = ngram_size_ - 1; offset >= 0; --offset)
-		ngram_hash_ = MurmurHashCombine(buffer_[(pos_ - offset) % ngram_size_], ngram_hash_);
+		ngram_.hash = MurmurHashCombine(buffer_[(pos_ - offset) % ngram_size_], ngram_.hash);
 	
 	++pos_;
 	++token_it_;

--- a/document-aligner/src/ngram.h
+++ b/document-aligner/src/ngram.h
@@ -5,9 +5,15 @@
 
 namespace bitextor {
 
-typedef uint64_t NGram;
+struct NGram {
+	uint64_t hash;
 
-class NGramIter : public boost::iterator_facade<NGramIter, const uint64_t, boost::forward_traversal_tag> {
+	inline bool operator==(NGram const &other) const {
+		return hash == other.hash;
+	}
+};
+
+class NGramIter : public boost::iterator_facade<NGramIter, const NGram, boost::forward_traversal_tag> {
 public:
 	NGramIter();
 	NGramIter(StringPiece const &source, size_t ngram_size);
@@ -29,7 +35,7 @@ private:
 	size_t pos_;
 	bool end_;
 	std::vector<uint64_t> buffer_;
-	NGram ngram_hash_;
+	NGram ngram_;
 
 	void init();
 	void increment();
@@ -40,8 +46,16 @@ private:
 
 	inline const NGram &dereference() const {
 		UTIL_THROW_IF(end_, util::OutOfTokens, "We already reached end");
-		return ngram_hash_;
+		return ngram_;
 	}
 };
 
 } // namespace bitextor
+
+namespace std {
+	template <> struct hash<bitextor::NGram> {
+		inline size_t operator()(bitextor::NGram const &val) const {
+			return val.hash;
+		}
+	};
+} // namespace std


### PR DESCRIPTION
Changes:
- Remove dead code. There was a sort() call left in there that's no longer necessary, there was an it==end() comparison that was always false. There was some unused code that's now gone.
- Push batches of documents through the queues. Reduces the load on the queues a bit when having many threads…
- Don't limit thread count on number of readers and number of scorers, let the OS figure out what gets priority. Because the queues are of limited size, if there are too many of one type of thread they'll just do nothing for a while, not costing much time.
- Make the hash function used by the unordered_maps that use ngrams as keys just a pass-through function. The ngrams themselves are already hashes which spread over the full uint64_t range.