### PR TITLE
Fix #180

### DIFF
--- a/bitextor-wget.py
+++ b/bitextor-wget.py
@@ -38,7 +38,6 @@ def check_wget_compression(cmd):
     except:
         return False
 
-
 def run(url, out_path, time_limit, agent, filetypes, warcfilename, wait):
     cmd = ""
     if time_limit:
@@ -93,7 +92,6 @@ def run(url, out_path, time_limit, agent, filetypes, warcfilename, wait):
             except:
                 pass
 
-
     system_check("rm {WARC}".format(WARC=warcfilebasename+".warc"))
 
 
@@ -120,21 +118,50 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print("Starting...")
+
     if '//' not in args.url:
         args.url = '%s%s' % ('http://', args.url)
-    try:
-        robots = requests.get(args.url + "/robots.txt", timeout=15).text.split("\n")
-        for line in robots:
-            if "Crawl-delay" in line:
-                try:
-                    crawldelay = int(line.split(':')[1].strip())
-                    if args.wait is None or crawldelay > int(args.wait):
-                        args.wait = str(crawldelay)
-                except ValueError:
-                    continue
-    except:
-        sys.stderr.write("WARNING: Error downloading robots.txt: ")
-        sys.stderr.write(str(sys.exc_info()[0]) + "\n")
-    run(args.url, args.outPath, args.timeLimit, args.agent, args.filetypes, args.warcfilename, args.wait)
+
+    url = args.url
+    connection_error = False
+
+    for check in range(2):
+        try:
+            connection = requests.get(url, timeout=15)
+        except requests.exceptions.ConnectTimeout:
+            if check:
+                connection_error = True
+            else:
+                url = "https" + url[4:]
+        except:
+            if check:
+                connection_error = True
+                sys.stderr.write("WARNING: error connecting: ")
+                sys.stderr.write(str(sys.exc_info()[0]) + "\n")
+
+    if not connection_error:
+        args.url = url
+
+        try:
+            robots = requests.get(args.url + "/robots.txt", timeout=15).text.split("\n")
+            for line in robots:
+                if "Crawl-delay" in line:
+                    try:
+                        crawldelay = int(line.split(':')[1].strip())
+                        if args.wait is None or crawldelay > int(args.wait):
+                            args.wait = str(crawldelay)
+                    except ValueError:
+                        pass
+        except:
+            sys.stderr.write("WARNING: Error downloading robots.txt: ")
+            sys.stderr.write(str(sys.exc_info()[0]) + "\n")
+
+        run(args.url, args.outPath, args.timeLimit, args.agent, args.filetypes, args.warcfilename, args.wait)
+    else:
+        # Create empty warc
+        warc_file_basename = args.warcfilename[0:args.warcfilename.find(".warc.gz")]
+        
+        with open(warc_file_basename + ".warc.gz", 'w') as f_out:
+            f_out.close()
 
     print("Finished!")

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1231,7 +1231,7 @@ rule heritrix_download:
 
             # Execute heritrix
             shell('echo hostname=$HOSTNAME; '
-                  'if [ "$(ps aux | grep -i Heritrix | grep -v grep)" == "" ] ; then {HERITRIXPATH}/bin/heritrix -a {HERITRIXUSER} ; fi ; '
+                  'if [ "$(ps aux | grep -i Heritrix | grep -v grep | grep -v heritrix\.warc\.gz)" == "" ] ; then {HERITRIXPATH}/bin/heritrix -a {HERITRIXUSER} ; fi ; '
                   'curl -v -d "action=teardown" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
                   'curl -v -d "createpath={wildcards.target}&action=create" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine; '
                   'DIRNAME=$(mktemp -d "{TMPDIR}/downloaded.{wildcards.target}.XXXXXX"); '

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1206,23 +1206,50 @@ rule heritrix_download:
     params:
         url="http://{target}"
     priority: 10
-    shell:
-        'echo hostname=$HOSTNAME; '
-        'if [ "$(ps aux | grep -i Heritrix | grep -v grep)" == "" ] ; then {HERITRIXPATH}/bin/heritrix -a {HERITRIXUSER} ; fi ; '
-        'curl -v -d "action=teardown" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
-        'curl -v -d "createpath={wildcards.target}&action=create" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine; '
-        'DIRNAME=$(mktemp -d "{TMPDIR}/downloaded.{wildcards.target}.XXXXXX"); '
-        'cat {BITEXTOR}/crawler-beans.cxml | sed "s@http://example.example/example@{params.url}@g" > $DIRNAME/my-crawler-beans.cxml; '
-        'curl -v -T $DIRNAME/my-crawler-beans.cxml -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}/jobdir/crawler-beans.cxml; '
-        'curl -v -d "action=build" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
-        'curl -v -d "action=launch&checkpoint=latest" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
-        'sleep 2; curl -v -d "action=unpause" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
-        'echo "Waiting for the warc.gz to be finished"; '
-        'RUNTIME=0; '
-        'sleep 15;'
-        'while [ -f {HERITRIXPATH}/jobs/{wildcards.target}/latest/warcs/*warc.gz.open ] ; do echo "Waiting 5 seconds..." ; sleep 5 ; RUNTIME=$((RUNTIME+5)) ; if [ "{CRAWLTIMELIMIT}" != "" ] ; then if [ $RUNTIME -gt "{CRAWLTIMELIMIT}" ] ; then echo "Crawling time limit reached" ; curl -v -d "action=pause" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; curl -v -d "action=checkpoint" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; curl -v -d "action=terminate" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; fi ; fi; done; '
-        'echo "Job {wildcards.target} finished!"; '
-        'cat {HERITRIXPATH}/jobs/{wildcards.target}/*/warcs/*warc.gz > {output}; '
+    run:
+        # Check the connection
+        url = params.url
+        connection_error = False
+        connection = None
+
+        for check in range(2):
+            try:
+                connection = requests.get(url, timeout=15)
+            except requests.exceptions.ConnectTimeout:
+                if check:
+                    connection_error = True
+                else:
+                    url = "https" + url[4:]
+            except:
+                if check:
+                    connection_error = True
+                    sys.stderr.write("WARNING: error connecting: ")
+                    sys.stderr.write(str(sys.exc_info()[0]) + "\n")
+
+        if not connection_error:
+            params.url = url
+
+            # Execute heritrix
+            shell('echo hostname=$HOSTNAME; '
+                  'if [ "$(ps aux | grep -i Heritrix | grep -v grep)" == "" ] ; then {HERITRIXPATH}/bin/heritrix -a {HERITRIXUSER} ; fi ; '
+                  'curl -v -d "action=teardown" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
+                  'curl -v -d "createpath={wildcards.target}&action=create" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine; '
+                  'DIRNAME=$(mktemp -d "{TMPDIR}/downloaded.{wildcards.target}.XXXXXX"); '
+                  'cat {BITEXTOR}/crawler-beans.cxml | sed "s@http://example.example/example@{params.url}@g" > $DIRNAME/my-crawler-beans.cxml; '
+                  'curl -v -T $DIRNAME/my-crawler-beans.cxml -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}/jobdir/crawler-beans.cxml; '
+                  'curl -v -d "action=build" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
+                  'curl -v -d "action=launch&checkpoint=latest" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
+                  'sleep 2; curl -v -d "action=unpause" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; '
+                  'echo "Waiting for the warc.gz to be finished"; '
+                  'RUNTIME=0; '
+                  'sleep 15;'
+                  'while [ -f {HERITRIXPATH}/jobs/{wildcards.target}/latest/warcs/*warc.gz.open ] ; do echo "Waiting 5 seconds..." ; sleep 5 ; RUNTIME=$((RUNTIME+5)) ; if [ "{CRAWLTIMELIMIT}" != "" ] ; then if [ $RUNTIME -gt "{CRAWLTIMELIMIT}" ] ; then echo "Crawling time limit reached" ; curl -v -d "action=pause" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; curl -v -d "action=checkpoint" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; curl -v -d "action=terminate" -k -u {HERITRIXUSER} --anyauth --location {HERITRIXURL}/engine/job/{wildcards.target}; fi ; fi; done; '
+                  'echo "Job {wildcards.target} finished!"; '
+                  'cat {HERITRIXPATH}/jobs/{wildcards.target}/*/warcs/*warc.gz > {output}; ')
+        else:
+            # Create empty warc file
+            with open(output[0], 'wb') as f_out:
+                f_out.close()
 
 
 def get_domain_hosts(wildcards):


### PR DESCRIPTION
Changes related to web servers which don't redirect to HTTPS from HTTP (issue #180).

Before the changes:
- wget: if the server doesn't redirect, there could be timeouts up to 20 * DNS entries * timeout.
- httrack: if the server doesn't redirect, the timeout is set to 30 seconds (only crawler which is not affected by #180).
- creepy: if the server doesn't redirect, urllib robot parser timeout + other connections.
- heritrix: if the server doesn't redirect, unknown but attempts to connect until the timeout is reached.