### PR TITLE
Integrations and fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 	path = bleualign-cpp
 	url = https://github.com/bitextor/bleualign-cpp
 	ignore = dirty
+[submodule "biroamer"]
+	path = biroamer
+	url = https://github.com/bitextor/biroamer.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -384,30 +384,30 @@ lang1: es
 lang2: en
 ```
 
-<!-- Two strategies are implemented in Bitextor for document alignment. The first one uses bilingual lexica to compute word-overlapping-based similarity metrics; these metrics are combined with other features that are extracted from HTML files and used by a linear regressor to obtain a similarity score. The second one uses machine translation (MT) and a [TF/IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) similarity metric computed on the original documents in `lang1` and the translations  of documents in `lang2`. Bitextor allows to build (if necessary) both the bilingual lexica and the MT system from parallel data. -->
-
-In current version, only one strategy for document alignment is included, which uses an external machine translation (MT) and a [TF/IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) similarity metric computed on the original documents in one of the languages, and the translation of the documents of the other language.
+Two strategies are implemented in Bitextor for document alignment. The first one uses bilingual lexica to compute word-overlapping-based similarity metrics; these metrics are combined with other features that are extracted from HTML files and used by a linear regressor to obtain a similarity score. The second one uses an external machine translation (MT) and a [TF/IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) similarity metric computed on the original documents in one of the languages, and the translation of the documents of the other language.
 
 ```yaml
 documentAligner: externalMT
 ```
 
-<!-- The variable `documentAligner` can take three different values, each of them taking a different document-alignment strategy:
+The variable `documentAligner` can take two different values, each of them taking a different document-alignment strategy:
+
+<!-- The variable `documentAligner` can take three different values, each of them taking a different document-alignment strategy: -->
 
 * `DIC`: takes the strategy using bilingual lexica and a linear regressor. NOTE: does not work with `giawarc: true`
 * `externalMT`: takes the strategy using MT, in this case using an external MT script (provided by the user) that reads source-language text from the standard input and writes the translations to the standard output
-* `NMT`: uses parallel data to train a neural MT (NMT) system that is then used for document alignment -->
+<!-- * `NMT`: uses parallel data to train a neural MT (NMT) system that is then used for document alignment -->
 
-<!-- #### Using bilingual lexica
+#### Using bilingual lexica
 
 ```yaml
 dic: /home/user/en-fr.dic
 ```
 
-Option `dic` specifies the path to the bilingual lexicon to be used for document alignment. If the lexicon specified does not exist, the pipeline will try to build it using a parallel corpus provided through the variable `initCorpusTrainPrefix` using `mgiza` tools:
+Option `dic` specifies the path to the bilingual lexicon to be used for document alignment. If the lexicon specified does not exist, the pipeline will try to build it using a parallel corpus provided through the variable `initCorpusTrainingPrefix` using `mgiza` tools:
 
 ```yaml
-initCorpusTrainPrefix: ['/home/user/Europarl.en-fr.train']
+initCorpusTrainingPrefix: ['/home/user/Europarl.en-fr.train']
 ```
 
 This variable must contain one or more **corpus prefixes**. For a given prefix (`/home/user/training` in the example) the pipeline expects to find one file `prefix`.`lang1` and another `prefix`.`lang2` (in the example, `/home/user/Europarl.en-fr.train.en` and `/home/user/Europarl.en-fr.train.fr`). If several training prefixes are provided, the corresponding files will be concatenated before building the bilingual lexicon.
@@ -419,7 +419,6 @@ If you are running out of memory in the `mkcls` rule, maybe you should activate 
 ```yaml
 mkcls: true
 ```
--->
 
 #### Using external MT
 
@@ -440,7 +439,7 @@ documentAlignerWorkers: 2
 If this option is chosen, a Marian NMT model will be trained and evaluated before using it for document alignment. Note that, given the computational cost of training an NMT system, this option requires having a GPU available. The following are mandatory variables in order to build the NMT system:
 
 ```yaml
-initCorpusTrainPrefix: ['/home/user/Europarl.en-fr.train']
+initCorpusTrainingPrefix: ['/home/user/Europarl.en-fr.train']
 initCorpusDevPrefix: ['/home/user/Europarl.en-fr.dev']
 initCorpusTestPrefix: ['/home/user/Europarl.en-fr.test']
 
@@ -457,7 +456,7 @@ gpuId: 0
 marianArgs: [" --optimizer-delay 1", "--mini-batch-fit", "--mini-batch 1000", "--maxi-batch 1000", "--overwrite", "--keep-best", "--valid-metrics perplexity", "--valid-log valid.log", "--log train.log", "--dropout-rnn 0.2", "--dropout-src 0.2", "--dropout-trg 0.2 ", "--cost-type ce-mean-words", "--layer-normalization", "--exponential-smoothing", "--tied-embeddings", "--valid-metrics bleu"]
 ```
 
-* `initCorpusTrainPrefix`, `initCorpusDevPrefix`,  and `initCorpusTestPrefix`: training data prefixes, development data prefixes and test data prefixes. See section *Variables for document alignment using bilingual lexica* for a description of such prefixes
+* `initCorpusTrainingPrefix`, `initCorpusDevPrefix`,  and `initCorpusTestPrefix`: training data prefixes, development data prefixes and test data prefixes. See section *Variables for document alignment using bilingual lexica* for a description of such prefixes
 * `marianDir`: path to the directory containing the installation of the NMT tool [Marian](https://github.com/marian-nmt/marian-dev)
 * `mosesDir`: path to the directory containing the MT tool [Moses](https://github.com/moses-smt/mosesdecoder); note that only data pre-processing scripts are used from Moses and, therefore, it is not necessary to compile the project to use it to train and NMT system
 * `subwordNmtDir`: path to the directory containing the installation of the tool [subword-nmt](https://github.com/rsennrich/subword-nmt)
@@ -469,16 +468,15 @@ marianArgs: [" --optimizer-delay 1", "--mini-batch-fit", "--mini-batch 1000", "-
 
 ### Segment alignment
 
-<!--- After document alignment, the next step in the pipeline is segment alignment. This can be carried out by using the tool [hunalign](http://mokk.bme.hu/resources/hunalign/) or the tool [bleualign](https://github.com/rsennrich/Bleualign). The first one uses a bilingual lexicon and is best suited for the `DIC` option of `documentAligner`; the second one uses MT and is only available if one of the options based on MT has been specified in `documentAligner`. --->
-After document aignment, the next step in the pipeline in segment alignment. Current version includes Bleualign as segment aligner.
+After document alignment, the next step in the pipeline is segment alignment. This can be carried out by using the tool [hunalign](http://mokk.bme.hu/resources/hunalign/) or the tool [bleualign](https://github.com/rsennrich/Bleualign). The first one uses a bilingual lexicon and is best suited for the `DIC` option of `documentAligner`; the second one uses MT and is only available if one of the options based on MT has been specified in `documentAligner`.
 
 ```yaml
-sentenceAligner: true
+sentenceAligner: bleualign
 sentenceAlignerThreshold: 0.1
 sentenceAlignerWorkers: 1
 ```
 
-* `sentenceAligner`: segment aligner tool, currently only `bleualign` is supported
+* `sentenceAligner`: segment aligner tool which is going to be used. Default is `bleualign`, but `hunalign` can be used in order to achieve a dictionary-based alignment.
 * `sentenceAlignerThreshold`: score threshold for filtering pairs of sentences with a score too low. For `bleualign` should be set to a value in [0,1], while `hunalign` can take any float value. Both are set to 0.0 by default
 
 ### Parallel data filtering
@@ -493,19 +491,17 @@ bicleanerThreshold: 0.6
 * `bicleaner`: path to the YAML configuration file of a pre-trained model. A number of pre-trained models are available [here](https://github.com/bitextor/bicleaner-data/releases/latest). They are ready to be downloaded and decompressed
 * `bicleanerThreshold`: threshold for the confidence score obtained with bitextor to filter low-confidence segment pairs. It is recommended to set it to values in [0.5,0.7], even though it is set to 0.0 by default
 
-<!--- If the Bicleaner model is not available, the pipeline will try to train one automatically from the data provided through the config file options `initCorpusTrainPrefix` and `bicleanerCorpusTrainingPrefix`:
+If the Bicleaner model is not available, the pipeline will try to train one automatically from the data provided through the config file options `initCorpusTrainingPrefix` and `bicleanerCorpusTrainingPrefix`:
 
 ```yaml
-initCorpusTrainPrefix: ['/home/user/Europarl.en-fr.train']
+initCorpusTrainingPrefix: ['/home/user/Europarl.en-fr.train']
 bicleanerCorpusTrainingPrefix: ['/home/user/RF.en-fr']
 ```
 
-* `initCorpusTrainPrefix`: prefix to parallel corpus (see section *Variables for document alignment using bilingual lexica*) that will be used to train statistical dictionaries which are part of the Bicleaner model
+* `initCorpusTrainingPrefix`: prefix to parallel corpus (see section *Variables for document alignment using bilingual lexica*) that will be used to train statistical dictionaries which are part of the Bicleaner model. This option affects and is affected by `dic` config option, which in case that provided `dic` does not exist, a new one will be generated; in case that provided `dic` does exist, should not be replaced (it does might!) but a new one would be generated and stored in "`dic`.generated". If `sentenceAligner: hunalign` is being used and this situation happens, the provided and existant `dic` will be used in the main pipeline while the new dictionary will only be used in order to train the Bicleaner model
 * `bicleanerCorpusTrainingPrefix`: prefix to the parallel corpus that will be used to train the regressor that obtains the confidence score in Bicleaner
 
 It is important to provide different parallel corpora for these two options as this helps Bicleaner when dealing with unknown words (that do not appear in the statistical dictionaries) during scoring.
-
---->
 
 ### Post-processing
 
@@ -513,13 +509,9 @@ Some other options can be configured to specify the output format of our corpus:
 
 ```yaml
 bifixer: true
-
 elrc: true
-
 tmx: true
-
 deduped: false
-
 deferred: false
 ```
 
@@ -530,6 +522,22 @@ deferred: false
 * `deferred`: if this option is set, segment contents (plain text or TMX) are deferred to the original location given a [standoff annotation](https://github.com/bitextor/standoff)
 
 NOTE: In case you need to convert a TMX to a tab-separated plain-text file (Moses format), you could use [TMXT](https://github.com/sortiz/tmxt) tool
+
+#### ROAM (Random, Omit, Anonymize and Mix) the resulted TMX
+
+In order to ROAM the resulted TMX (either normal or deduped), you can use some options to configure the result:
+
+```yaml
+biroamer: true
+biroamerOmitRandomSentences: true
+biroamerMixFiles: ["/home/user/file-tp-mix1", "/home/user/file-to-mix2"]
+biroamerImproveAlignmentCorpus: /home/user/Europarl.en-fr.txt
+```
+
+* `biroamer`: through this option we enable the ROAM feature. In order to ROAM the resulted TMX, [Biroamer](https://github.com/bitextor/biroamer) is used. If this option is set to 'true', `tmx: true` or `deduped: true` will be necessary.
+* `biroamerOmitRandomSentences`: in order to omit random sentences, this option can be used. The quantity of sentences removed are close to 10% of the original TMX.
+* `biroamerMixFiles`: when is necessary to add external sentences to improve anonymization, this option accepts a list of files which will add the stored sentences. The files are expected to be in morse format, and those files will be concatenated.
+* `biroamerImproveAlignmentCorpus`: an alignment corpus can be provided in order to improve the entities detection. The corpus file is exteced to be in morse format.
 
 ## Pipeline description
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -525,6 +525,24 @@ NOTE: In case you need to convert a TMX to a tab-separated plain-text file (Mose
 
 #### ROAM (Random, Omit, Anonymize and Mix) the resulted TMX
 
+##### Dependencies
+
+[Biroamer](https://github.com/bitextor/biroamer) has dependencies. If you want to be able to execute it, you will need to install the following dependencies (using an apt-like dependencies manager):
+
+```bash
+sudo apt install libgoogle-perftools-dev libsparsehash-dev
+```
+
+Once you have installed the general dependencies, python dependencies need to be installed as well:
+
+```bash
+pip3 install -r biroamer/requirements.txt
+```
+
+In the case that the described steps do not work as expected, check out [biroamer's site](https://github.com/bitextor/biroamer).
+
+##### Configuration
+
 In order to ROAM the resulted TMX (either normal or deduped), you can use some options to configure the result:
 
 ```yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -476,8 +476,8 @@ sentenceAlignerThreshold: 0.1
 sentenceAlignerWorkers: 1
 ```
 
-* `sentenceAligner`: segment aligner tool which is going to be used. Default is `bleualign`, but `hunalign` can be used in order to achieve a dictionary-based alignment.
-* `sentenceAlignerThreshold`: score threshold for filtering pairs of sentences with a score too low. For `bleualign` should be set to a value in [0,1], while `hunalign` can take any float value. Both are set to 0.0 by default
+* `sentenceAligner`: segment aligner tool which is going to be used. Default is `bleualign`, but `hunalign` can be used in order to achieve a dictionary-based alignment. If `bleualign` is used, `documentAligner: externalMT` is mandatory, but in the case of `hunalign`, both `externalMT` and `DIC` are allowed as document aligner.
+* `sentenceAlignerThreshold`: score threshold for filtering pairs of sentences with a score too low. The value should be set to a value in [0,1] (both `bleualign` and `hunalign`). The default value is 0.0.
 
 ### Parallel data filtering
 

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1048,7 +1048,7 @@ rule roam_tmx:
         tokenizer_l2 = lambda wildcards: apply_format(get_lang_or_default(WORDTOKS, LANG2), "-T \"{}\""),
         mix_files = '/dev/null' if not 'biroamerMixFiles' in config or len(config['biroamerMixFiles']) == 0 else ' '.join(config['biroamerMixFiles']),
         alignment_corpus = "" if "biroamerImproveAlignmentCorpus" not in config else f"-a {config['biroamerImproveAlignmentCorpus']}",
-        omit = "" if not config['biroamerOmitRandomSentences'] else "-o",
+        omit = "" if "biroamerOmitRandomSentences" not in config or not config['biroamerOmitRandomSentences'] else "-o",
     shell: '''
         mix_files="$(mktemp {TMPDIR}/roam_tmx_mix.{LANG1}-{LANG2}.XXXXXX)"
         cat {params.mix_files} > $mix_files

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -2,12 +2,14 @@ import os
 import sys
 import requests
 
-include: "utils.smk"
-
-config = validate_args(config)
+#include: "utils.smk"
 
 sys.path.append(os.path.dirname(os.path.abspath(config["bitextor"]) + "/utils"))
+from utils.args import validate_args
 from utils.common import open_xz_or_gzip_or_plain
+from utils.non_generic import *
+
+config = validate_args(config)
 
 #################################################################
 # BASIC PARAMETERS
@@ -16,6 +18,9 @@ DATADIR = config["dataDir"]
 TRANSIENT = config["transientDir"]
 PERMANENT = config["permanentDir"]
 TMPDIR = config["tempDir"]
+CONFIGFILE = workflow.overwrite_configfiles
+WORKDIR = os.getcwd()
+SNAKEMAKEDIR = os.path.dirname(workflow.snakefile)
 
 LANGS = set()
 LANG1 = ""
@@ -33,6 +38,16 @@ if "lang2" in config:
 PROFILING = ""
 if "profiling" in config and config["profiling"]:
     PROFILING = "/usr/bin/time -v"
+if CONFIGFILE is None or (isinstance(CONFIGFILE, list) and len(CONFIGFILE) == 0):
+    CONFIGFILE = workflow.configfiles
+if CONFIGFILE is None or (isinstance(CONFIGFILE, list) and len(CONFIGFILE) == 0):
+    sys.stderr.write("WARNING: could not retrieve the config file path. Some functionalities might not be available\n")
+    CONFIGFILE = None
+elif isinstance(CONFIGFILE, list):
+    if len(CONFIGFILE) > 1:
+        sys.stderr.write(f"WARNING: multiple elements found in config file path. Using the first element")
+    CONFIGFILE = CONFIGFILE[0]
+
 #################################################################
 # CRAWLING
 CRAWLTARGET = ""
@@ -129,6 +144,15 @@ CUSTOMNBPS = {} if not "customNBPs" in config else config["customNBPs"]
 WORDTOKS = {} if not "wordTokenizers" in config else config["wordTokenizers"]
 MORPHTOKS = {} if not "morphologicalAnalysers" in config else config["morphologicalAnalysers"]
 
+# Concrete tokenizers and morph. tokenizers
+if WORDTOKS:
+    WORDTOK1 = get_lang_or_default(WORDTOKS, LANG1)
+    WORDTOK2 = get_lang_or_default(WORDTOKS, LANG2)
+else:
+    WORDTOK1, WORDTOK2 = f"{BITEXTOR}/preprocess/moses/tokenizer/tokenizer.perl -q -b -a -l {LANG1}", f"{BITEXTOR}/preprocess/moses/tokenizer/tokenizer.perl -q -b -a -l {LANG2}"
+MORPHTOK1 = get_lang_or_default(MORPHTOKS, LANG1)
+MORPHTOK2 = get_lang_or_default(MORPHTOKS, LANG2)
+
 PRUNE_THRESHOLD = f"--prune {config['pruneThreshold']}"
 PRUNE_TYPE = f"--prune-type {config['pruneType']}"
 
@@ -136,8 +160,10 @@ PRUNE_TYPE = f"--prune-type {config['pruneType']}"
 # DOCALIGN
 DOCALIGN = config["documentAligner"]
 # mt
-# TODO KeyError if documentAligner: DIC and alignerCmd not defined
-MT_COMMAND = config['alignerCmd']
+if DOCALIGN == "externalMT":
+    MT_COMMAND = config['alignerCmd']
+else:
+    MT_COMMAND = None
 SRC_LANG = LANG1
 TRG_LANG = LANG2
 if "translationDirection" in config and config["translationDirection"] == f'{LANG2}2{LANG1}':
@@ -147,13 +173,26 @@ if "translationDirection" in config and config["translationDirection"] == f'{LAN
 DOC_THRESHOLD = 0.1
 if "documentAlignerThreshold" in config:
     DOC_THRESHOLD = config["documentAlignerThreshold"]
+
+#################################################################
 # dic
 # TODO
+
+DIC=None
+DIC_TRAINING=None
+
+if "dic" in config:
+    DIC = config["dic"]
+    DIC_TRAINING = DIC
+
+    if os.path.isfile(DIC) and ('bicleanerCorpusTrainingPrefix' in config and 'initCorpusTrainingPrefix' in config):
+        DIC_TRAINING += ".generated"
+
 #################################################################
 # SEGALIGN
 SEGALIGN = config["sentenceAligner"]
 # bleualign
-BLEU_TRESHOLD = 0.1
+BLEU_THRESHOLD = 0.1
 if "sentenceAlignerThreshold" in config:
     BLEU_THRESHOLD=config["sentenceAlignerThreshold"]
 # hunalign
@@ -174,6 +213,7 @@ ELRC = False
 ELRC_FIELDS = []
 TMX = False
 DEDUPED = False
+BIROAMER = False
 # TODO: add rawCorpus option to generate lang1-lang2.raw.gz
 OUTPUT_FILES = ["sent", "raw"]
 
@@ -199,8 +239,16 @@ if 'tmx' in config and config['tmx']:
     TMX = True
     OUTPUT_FILES.append('not-deduped.tmx')
 if 'deduped' in config and config['deduped']:
+    DEDUPED = True
     OUTPUT_FILES.append('deduped.tmx')
     OUTPUT_FILES.append('deduped.txt')
+if 'biroamer' in config and config['biroamer']:
+    BIROAMER = True
+
+    if 'deduped.tmx' in OUTPUT_FILES:
+        OUTPUT_FILES.append('deduped-roamed.tmx')
+    else:
+        OUTPUT_FILES.append('not-deduped-roamed.tmx')
 
 BEFORE_ELRC_FIELDS = FIELDS + DEFERRED_FIELDS + BIFIXER_FIELDS + BICLEANER_FIELDS
 TMX_FIELDS = BEFORE_ELRC_FIELDS + ELRC_FIELDS
@@ -288,8 +336,16 @@ else:
     elif UNTIL == 'filter':
         OUTPUT.append(f'{TRANSIENT}/07_03.filter.{LANG1}_{LANG2}')
 shell.prefix("set -euo pipefail;")
+
+#################################################################
+### FINAL OUTPUTS ###############################################
 rule all:
     input: OUTPUT
+
+#################################################################
+### INCLUDE #####################################################
+include: "include/dic-generation/Snakefile"
+include: "include/dic-docsegalign/Snakefile"
 
 #################################################################
 ### CRAWLING ####################################################
@@ -463,8 +519,13 @@ checkpoint shard:
             mkdir -p {params.o}/{params.empty_shard_batch_folder}
 
             touch {params.o}/{params.empty_shard_batch_folder}/empty
-            touch {params.o}/{params.empty_shard_batch_folder}/{{plain_text,url,normalized_html}}
-            gzip {params.o}/{params.empty_shard_batch_folder}/{{plain_text,url,normalized_html}}
+            if [[ "{PPROC}" == "giawarc" ]]; then
+                touch {params.o}/{params.empty_shard_batch_folder}/{{plain_text,url,normalized_html}}
+                gzip {params.o}/{params.empty_shard_batch_folder}/{{plain_text,url,normalized_html}}
+            else
+                touch {params.o}/{params.empty_shard_batch_folder}/{{plain_text,mime,url,normalized_html,deboilerplate_html}}
+                gzip {params.o}/{params.empty_shard_batch_folder}/{{plain_text,mime,url,normalized_html,deboilerplate_html}}
+            fi
 
             mylang="{SRC_LANG}"
             notmylang="{TRG_LANG}"
@@ -496,8 +557,13 @@ checkpoint shard:
 
                 # Create the same shards that have been created in the other lang (only 1 batch)
                 ls -d {params.o_no_lang}/$notmylang/* | xargs -I[] basename [] | xargs -I[] mkdir -p {params.o_no_lang}/$mylang/[]/1
-                ls -d {params.o}/*/* | xargs -I[] touch []/{{plain_text,url,normalized_html}}
-                ls -d {params.o}/*/* | xargs -I[] gzip []/{{plain_text,url,normalized_html}}
+                if [[ "{PPROC}" == "giawarc" ]]; then
+                    ls -d {params.o}/*/* | xargs -I[] touch []/{{plain_text,url,normalized_html}}
+                    ls -d {params.o}/*/* | xargs -I[] gzip []/{{plain_text,url,normalized_html}}
+                else
+                    ls -d {params.o}/*/* | xargs -I[] touch []/{{plain_text,mime,url,normalized_html,deboilerplate_html}}
+                    ls -d {params.o}/*/* | xargs -I[] gzip []/{{plain_text,mime,url,normalized_html,deboilerplate_html}}
+                fi
             fi
         fi
 
@@ -585,7 +651,10 @@ rule custom_translate:
         '''
         # TODO: add early stopping
 
-translation_output = rules.custom_translate.output
+if MT_COMMAND is None:
+    translation_output = f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{src_batch}}/sentences.gz'
+else:
+    translation_output = rules.custom_translate.output
 
 rule aggregate_translate:
     input: lambda wildcards: [f'{batch}/sentences_{TRG_LANG}.gz' for batch in get_batches(SRC_LANG)]
@@ -630,6 +699,25 @@ rule tokenise_target:
             | pigz -c > {output}
         '''
 
+rule tokenise_source:
+    input: f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/sentences.gz'
+    output: f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/tokenised.gz'
+    params:
+        tokeniser = lambda wildcards: apply_format(get_lang_or_default(WORDTOKS, TRG_LANG), "--word-tokenizer \"{}\""),
+        lemmatizer = lambda wildcards: apply_format(get_lang_or_default(MORPHTOKS, TRG_LANG), "--morph-analyser \"{}\"")
+    threads: THREADS['tokenise_src']
+    shell: '''
+        parallel_cmd=""
+        if [ {threads} -gt 1 ]; then
+            parallel_cmd="parallel --gnu --halt 2 --pipe --j {threads} -k"
+        fi
+        zcat {input} \
+            | {PROFILING} ${{parallel_cmd}} {BITEXTOR}/bitextor-tokenize.py \
+                {params.tokeniser} {params.lemmatizer} \
+                --langcode {SRC_LANG} \
+            | pigz -c > {output}
+        '''
+
 rule aggregate_tokenise_target:
     input: lambda wildcards: [f'{batch}/tokenised.gz' for batch in get_batches(TRG_LANG)]
     output: f'{DATADIR}/shards/05.tokenise.{TRG_LANG}'
@@ -647,7 +735,10 @@ rule mt_matches:
     output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.06_01.matches'
     params: folder=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}'
     threads: THREADS['docalign']
-    shell: "mkdir -p {params.folder}; {PROFILING} {BITEXTOR}/document-aligner/bin/docalign {input.l1} {input.l2} --threshold {DOC_THRESHOLD} -j {threads} > {output}"
+    shell: '''
+        mkdir -p {params.folder}
+        {PROFILING} {BITEXTOR}/document-aligner/bin/docalign {input.l1} {input.l2} --threshold {DOC_THRESHOLD} -j {threads} > {output}
+        '''
 # DIC ###########################################################
 # TODO
 #################################################################
@@ -665,7 +756,9 @@ rule bleualign:
         url1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
         url2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
         translated1=translation_output
-    params: folder=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}', workers=THREADS['segalign']
+    params:
+        folder=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}',
+        workers=THREADS['segalign']
     # in segalign rule output columns are reordered (or not) in accordance with translationDirection
     output: temp(f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.06_02.segalign.gz')
     threads: max(THREADS['segalign'], 2)
@@ -680,7 +773,7 @@ rule bleualign:
                 -l {input.url1} -r {input.url2} \
                 -l {input.plain1} -r {input.plain2} \
                 -l {input.translated1} \
-            | {PROFILING} ${{parallel_cmd}} {BITEXTOR}/bleualign-cpp/bleualign_cpp --bleu-threshold {BLEU_TRESHOLD} \
+            | {PROFILING} ${{parallel_cmd}} {BITEXTOR}/bleualign-cpp/bleualign_cpp --bleu-threshold {BLEU_THRESHOLD} \
             | pigz -c > {output}
         '''
 # HUNALIGN ######################################################
@@ -704,9 +797,11 @@ rule deferred_documents:
             | awk -F $'\t' '{{ print $1 | "xz > {output.text}"; print $3 | "xz > {output.deferred}" }}'
         '''
 
+# Default: bleualign
 deferred_input = rules.bleualign.output
-# if SEGALIGN == "hunalign":
-#     deferred_input = rules.hunalign.output
+
+if SEGALIGN == "hunalign":
+    deferred_input = rules.dic_docsegalign_alignsegments_hunalign.output
 
 rule deferred_segments:
     input:
@@ -724,11 +819,17 @@ rule deferred_segments:
             > {output}
         '''
 
-split_input_filename = '06_02.segalign'
-split_input_extension = '.gz'
 if DEFERRED:
     split_input_filename = '07_00.deferred'
     split_input_extension = ''
+else:
+    # Default: bleualign
+    split_input_filename = '06_02.segalign'
+    split_input_extension = '.gz'
+
+    if SEGALIGN == "hunalign":
+        split_input_filename = 'hunalign.06_02.segalign'
+        split_input_extension = '.xz'
 
 # split segalign results into balanced chunks
 checkpoint split_segalign:
@@ -740,7 +841,12 @@ checkpoint split_segalign:
     shell: '''
         mkdir -p {params.folder}
         rm -f {params.folder}/* # remove anything that might be left after a previous run
-        CAT=cat; if [[ {input[0]} == *.gz ]]; then CAT=zcat; fi
+        CAT=cat
+        if [[ {input[0]} == *.gz ]]; then
+            CAT=zcat
+        elif [[ {input[0]} == *.xz ]]; then
+            CAT=xzcat
+        fi
         $CAT {input} \
             | ( [ "{SRC_LANG}" = "{LANG1}" ] && cat || awk -F '\t' '{{ print $2,$1,$4,$3,$5 }}' OFS='\t' )\
             | python3 {BITEXTOR}/utils/split.py -f 3,4 -s {params.size} --gzip -o "{params.folder}/"
@@ -781,6 +887,37 @@ rule aggregate_bifixer:
 bicleaner_input = rules.bifixer.output
 if not BIFIXER:
     bicleaner_input = rules.bifixer.input.segalign
+
+if "bicleanerCorpusTrainingPrefix" in config:
+    bicleanerTrainPrefixes=config["bicleanerCorpusTrainingPrefix"]
+else:
+    bicleanerTrainPrefixes=None
+
+rule bicleaner_train_model:
+    input:
+        corpusl1=expand("{dataset}.{lang}.xz", dataset=bicleanerTrainPrefixes, lang=LANG1),
+        corpusl2=expand("{dataset}.{lang}.xz", dataset=bicleanerTrainPrefixes, lang=LANG2),
+        e2f=f"{DIC_TRAINING}.lex.e2f.gz",
+        f2e=f"{DIC_TRAINING}.lex.f2e.gz",
+        vcb1=f"{mgizaModelDir}/corpus.{LANG1}.filtered.vcb.gz",
+        vcb2=f"{mgizaModelDir}/corpus.{LANG2}.filtered.vcb.gz",
+        dic=f"{DIC_TRAINING}",  # If DIC != DIC_TRAINING, DIC_TRAINING will be generated but not used because of this input
+                                # This input makes the dictionary to be generated (without it, statistical info would be generated but not the dic)
+    output:
+        model=BICLEANER_MODEL
+
+    shell: '''
+        training=$(mktemp {TMPDIR}/train.XXXXXXXX)
+        paste <(xzcat -f {input.corpusl1}) <(xzcat -f {input.corpusl2}) > $training
+        DIR=$(dirname {BICLEANER_MODEL})
+        echo $DIR
+        lines=$(cat $training | wc -l)
+        trainlines=$(echo \"$lines*4/10\" | bc)
+        testlines=$(echo \"($lines-2*$trainlines)/2\" | bc)
+        # Parameters for good/bad examples have been removed -> now the whole file is being used (https://github.com/bitextor/bicleaner/commit/cdd1bc03928701884cd42ffac4b602220ec3e732)
+        {PROFILING} python3  {BITEXTOR}/bicleaner/bicleaner/bicleaner_train.py $training -S "{WORDTOK1}" -T "{WORDTOK2}" --treat_oovs --normalize_by_length -s {LANG1} -t {LANG2} -d {input.e2f} -D {input.f2e} -f {input.vcb1} -F {input.vcb2} -c $DIR/{LANG1}-{LANG2}.classifier -m {BICLEANER_MODEL} --classifier_type random_forest
+        rm $training
+        '''
 
 rule bicleaner:
     input: bifixer=bicleaner_input, model=BICLEANER_MODEL
@@ -841,7 +978,7 @@ rule aggregate_filter:
 
 raw_input_filename = rules.filter.input[0].split('/')[-2] # 06_02.segalign / 07_01.bifixer / 07_02.bicleaner
 extension = ""
-if raw_input_filename in ["07_02.bicleaner", "06_02.segalign", "07_00.deferred"]:
+if raw_input_filename in ["07_02.bicleaner", "06_02.segalign", "07_00.deferred", "hunalign.06_02.segalign"]:
     extension = ".gz"
 
 rule raw:
@@ -899,4 +1036,40 @@ rule deduped_tmx:
         echo "Sentence pairs: $(echo $WC1 | cut -d ' ' -f 1)" >> {output.stats}
         echo "{LANG1} words: $(echo $WC1 | cut -d ' ' -f 2)" >> {output.stats}
         echo "{LANG2} words: $WC2" >> {output.stats}
+        '''
+
+rule roam_tmx:
+    input:
+        tmx=rules.tmx.output if not DEDUPED else rules.deduped_tmx.output.tmx,
+        txt=rules.sents.output if not DEDUPED else rules.deduped_tmx.output.txt
+    output: f'{PERMANENT}/{LANG1}-{LANG2}.not-deduped-roamed.tmx.gz' if not DEDUPED else f'{PERMANENT}/{LANG1}-{LANG2}.deduped-roamed.tmx.gz'
+    params:
+        tokenizer_l1 = lambda wildcards: apply_format(get_lang_or_default(WORDTOKS, LANG1), "-t \"{}\""),
+        tokenizer_l2 = lambda wildcards: apply_format(get_lang_or_default(WORDTOKS, LANG2), "-T \"{}\""),
+        mix_files = '/dev/null' if not 'biroamerMixFiles' in config or len(config['biroamerMixFiles']) == 0 else ' '.join(config['biroamerMixFiles']),
+        alignment_corpus = "" if "biroamerImproveAlignmentCorpus" not in config else f"-a {config['biroamerImproveAlignmentCorpus']}",
+        omit = "" if not config['biroamerOmitRandomSentences'] else "-o",
+    shell: '''
+        mix_files="$(mktemp {TMPDIR}/roam_tmx_mix.{LANG1}-{LANG2}.XXXXXX)"
+        cat {params.mix_files} > $mix_files
+        nolines=$(cat $mix_files | wc -l)
+
+        if [[ "$nolines" != "0" ]]; then
+            mix_files="-m $mix_files"
+        else
+            mix_files=""
+        fi
+
+        nolines_txt=$(cat {input.txt} | wc -l)
+        total_nolines=$(echo $nolines + $nolines_txt | bc)
+
+        if [[ "$total_nolines" -lt "100000" ]] && [[ "{params.alignment_corpus}" == "" ]]; then
+            >&2 echo "WARNING: biroamer suggests, at least, 100k lines in order to have a good alignment (current nolines: $total_nolines)."\
+                     "Check 'biroamerImproveAlignmentCorpus' config option if you want to improve the resulted roamed tmx"
+        fi
+
+        zcat {input.tmx} \
+            | {PROFILING} {BITEXTOR}/biroamer/biroamer.sh {params.tokenizer_l1} {params.tokenizer_l2} \
+                {params.omit} {params.alignment_corpus} $mix_files {LANG1} {LANG2} 2> /dev/null \
+            | pigz -c > {output}
         '''

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -174,9 +174,11 @@ DOC_THRESHOLD = 0.1
 if "documentAlignerThreshold" in config:
     DOC_THRESHOLD = config["documentAlignerThreshold"]
 
+# dic-based docalign
+# snakemake/include/dic-docsegalign
 #################################################################
 # dic
-# TODO
+# snakemake/include/dic-generation
 
 DIC=None
 DIC_TRAINING=None
@@ -192,11 +194,11 @@ if "dic" in config:
 # SEGALIGN
 SEGALIGN = config["sentenceAligner"]
 # bleualign
-BLEU_THRESHOLD = 0.1
+SEGALIGN_THRESHOLD = 0.0
 if "sentenceAlignerThreshold" in config:
-    BLEU_THRESHOLD=config["sentenceAlignerThreshold"]
+    SEGALIGN_THRESHOLD=config["sentenceAlignerThreshold"]
 # hunalign
-# TODO
+# snakemake/include/dic-docsegalign
 #################################################################
 # CLEANING
 FIELDS = ['url1','url2','seg1','seg2','aligner']
@@ -652,7 +654,7 @@ rule custom_translate:
         # TODO: add early stopping
 
 if MT_COMMAND is None:
-    translation_output = f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{src_batch}}/sentences.gz'
+    translation_output = f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/sentences.gz'
 else:
     translation_output = rules.custom_translate.output
 
@@ -739,14 +741,13 @@ rule mt_matches:
         mkdir -p {params.folder}
         {PROFILING} {BITEXTOR}/document-aligner/bin/docalign {input.l1} {input.l2} --threshold {DOC_THRESHOLD} -j {threads} > {output}
         '''
-# DIC ###########################################################
-# TODO
-#################################################################
+
 ### SEGALIGN ####################################################
 rule aggregate_segalign:
     input: lambda wildcards: [f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{shard}/{SRC_LANG}{src_batch}_{TRG_LANG}{trg_batch}.06_02.segalign.gz' for (shard, (src_batch, trg_batch)) in get_align_inputs(SRC_LANG, TRG_LANG)]
     output: f'{TRANSIENT}/06_02.segalign.{LANG1}_{LANG2}'
     shell: ''' echo {input} | tr ' ' '\n' > {output} '''
+
 # BLEUALIGN #####################################################
 rule bleualign:
     input:
@@ -773,12 +774,10 @@ rule bleualign:
                 -l {input.url1} -r {input.url2} \
                 -l {input.plain1} -r {input.plain2} \
                 -l {input.translated1} \
-            | {PROFILING} ${{parallel_cmd}} {BITEXTOR}/bleualign-cpp/bleualign_cpp --bleu-threshold {BLEU_THRESHOLD} \
+            | {PROFILING} ${{parallel_cmd}} {BITEXTOR}/bleualign-cpp/bleualign_cpp --bleu-threshold {SEGALIGN_THRESHOLD} \
             | pigz -c > {output}
         '''
-# HUNALIGN ######################################################
-# TODO
-#################################################################
+
 ### FILTERING AND CLEANING ######################################
 
 # TODO: deferred_documents does not work with giawarc: html of the original document not saved

--- a/snakemake/include/dic-docsegalign/Snakefile
+++ b/snakemake/include/dic-docsegalign/Snakefile
@@ -1,0 +1,197 @@
+
+
+#################################################################
+### DOCALIGN ####################################################
+# DICTIONARY-BASED ##############################################
+rule dic_docsegalign_lettr2idx:
+    input:
+        text1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/tokenised.gz',
+        text2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/tokenised.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.idx.xz',
+    shell: '''
+        {PROFILING} {BITEXTOR}/bitextor-buildidx.py  --lang1 {SRC_LANG} --lang2 {TRG_LANG} -m 15 --text1 {input.text1} --text2 {input.text2} | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_idx2ridx_l1tol2:
+    input:
+        idx=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.idx.xz',
+        dic=expand("{dic}", dic=DIC)
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.1.ridx.xz',
+    shell: '''
+        xzcat -T 0 -f {input.idx} \
+            | {PROFILING} {BITEXTOR}/bitextor-idx2ridx.py -d {input.dic} --lang1 {SRC_LANG} --lang2 {TRG_LANG} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_idx2ridx_l2tol1:
+    input:
+        idx=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.idx.xz',
+        dic=expand("{dic}", dic=DIC)
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.2.ridx.xz',
+    shell: '''
+        xzcat -T 0 -f {input.idx} \
+            | {PROFILING} {BITEXTOR}/bitextor-idx2ridx.py -d {input.dic} --lang1 {TRG_LANG} --lang2 {SRC_LANG} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_ridx2imagesetoverlap:
+    input:
+        ridx=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.ridx.xz',
+        debpl_html_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/deboilerplate_html.gz',
+        debpl_html_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/deboilerplate_html.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.imgoverlap.xz',
+    shell: '''
+        xzcat -T 0 -f {input.ridx} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-imagesetoverlap.py --html1 {input.debpl_html_l1} --html2 {input.debpl_html_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_imagesetoverlap2structuredistance:
+    input:
+        imagesetoverlap=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.imgoverlap.xz',
+        debpl_html_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/deboilerplate_html.gz',
+        debpl_html_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/deboilerplate_html.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.structuredistance.xz',
+    shell: '''
+        xzcat -T 0 -f {input.imagesetoverlap} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-structuredistance.py --html1 {input.debpl_html_l1} --html2 {input.debpl_html_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_structuredistance2urldistance:
+    input:
+        structuredistance=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.structuredistance.xz',
+        debpl_html_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/deboilerplate_html.gz',
+        debpl_html_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/deboilerplate_html.gz',
+        url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
+        url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urldistance.xz',
+    priority: 8
+    shell: '''
+        xzcat -T 0 -f {input.structuredistance} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-urlsdistance.py \
+                --html1 {input.debpl_html_l1} --html2 {input.debpl_html_l2} \
+                --url1 {input.url_l1} --url2 {input.url_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_urldistance2mutuallylinked:
+    input:
+        urldistance=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urldistance.xz',
+        debpl_html_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/deboilerplate_html.gz',
+        debpl_html_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/deboilerplate_html.gz',
+        url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
+        url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.mutuallylinked.xz',
+    shell: '''
+        xzcat -T 0 -f {input.urldistance} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-mutuallylinked.py \
+                --html1 {input.debpl_html_l1} --html2 {input.debpl_html_l2} \
+                --url1 {input.url_l1} --url2 {input.url_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_mutuallylinked2urlscomparison:
+    input:
+        mutuallylinked=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.mutuallylinked.xz',
+        url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
+        url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urlscomparison.xz',
+    shell: '''
+        xzcat -T 0 -f {input.mutuallylinked} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-urlscomparison.py --url1 {input.url_l1} --url2 {input.url_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_urlscomparison2urlsoverlap:
+    input:
+        urlscomparison=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urlscomparison.xz',
+        debpl_html_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/deboilerplate_html.gz',
+        debpl_html_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/deboilerplate_html.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urlsoverlap.xz',
+    shell: '''
+        xzcat -T 0 -f {input.urlscomparison} \
+            | {PROFILING} {BITEXTOR}/features/bitextor-urlsetoverlap.py --html1 {input.debpl_html_l1} --html2 {input.debpl_html_l2} \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_urlsoverlap2rank:
+    input: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.urlsoverlap.xz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{{num}}.rank.xz',
+    shell: '''
+        xzcat -T 0 -f {input} \
+            | {PROFILING} {BITEXTOR}/bitextor-rank.py -m {BITEXTOR}/model/keras.model -w {BITEXTOR}/model/keras.weights \
+            | xz -T 0 > {output}
+        '''
+
+rule dic_docsegalign_aligndocumentsBitextor:
+    input:
+        rank1=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.1.rank.xz',
+        rank2=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.2.rank.xz',
+        url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
+        url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.bitextor.06_01.matches'
+    shell: '''
+        {PROFILING} {BITEXTOR}/bitextor-align-documents.py \
+            --lines1 $(zcat {input.url_l1} | wc -l) --lines2 $(zcat {input.url_l2} | wc -l) \
+            -n 1 -i converge -r /dev/null {input.rank1} {input.rank2} > {output}
+        '''
+
+#################################################################
+### SEGALIGN ####################################################
+# HUNALIGN ######################################################
+
+rule dic_docsegalign_matches2hunalign:
+    input:
+        indices=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.bitextor.06_01.matches',
+        plain1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/sentences.gz',
+        plain2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/sentences.gz',
+        url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
+        url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
+        tok1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/tokenised.gz',
+        tok2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/tokenised.gz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.hunalign.docalign.bitextor.06_02.matches.xz',
+    params:
+        #c1=lambda wildcards: 1 if wildcards.docalignext == 'bitextor' else 2,
+        #c2=lambda wildcards: 2 if wildcards.docalignext == 'bitextor' else 3
+        # TODO are there other doc. aligners which should work with hugnalign?
+        c1=1,
+        c2=2
+    shell: '''
+        cut -f {params.c1},{params.c2} {input.indices} \
+            | LC_ALL=C sort -nk1 \
+            | {PROFILING} python3 {BITEXTOR}/bitextor-build-docalign.py \
+                --columns1 {input.url_l1} {input.plain1} {input.tok1} --columns2 {input.url_l2} {input.plain2} {input.tok2} \
+            | awk -F\'\t\' \'{{print $2,$6,$3,$7,$4,$8}}\' OFS=\'\t\' \
+            | xz -T 0 -f > {output} # Format: url1 <tab> url2 <tab> text1 <tab> text2 <tab> tok1 <tab> tok2
+        '''
+
+rule dic_docsegalign_hunaligndic:
+    input: expand("{dic}", dic=DIC)
+    output: f'{DATADIR}/hunalign_dic'
+    run:
+        with open(output[0], "wt") as outw:
+            with open(input[0], "rt") as inr:
+                header=inr.readline().strip()
+                langs=header.split("\t")
+                if langs[0] == LANG1 and langs[1] == LANG2:
+                    inverse=True
+                else:
+                    inverse=False
+                for inline in inr:
+                    columns=inline.strip().split("\t")
+                    if inverse:
+                        outw.write(columns[1]+" @ "+columns[0]+"\n")
+                    else:
+                        outw.write(columns[0]+" @ "+columns[1]+"\n")
+
+rule dic_docsegalign_alignsegments_hunalign:
+    input:
+        hunaligndic=rules.dic_docsegalign_hunaligndic.output,
+        hunalign_matches=rules.dic_docsegalign_matches2hunalign.output,
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.hunalign.06_02.segalign.xz'
+    shell: '''
+        xzcat -T 0 {input.hunalign_matches} \
+            | {PROFILING} {BITEXTOR}/bitextor-align-segments.py -d {input.hunaligndic} -t {TMPDIR} --hunalign-dir "{BITEXTOR}/hunalign/src/hunalign" \
+            | xz -T 0 > {output}
+        '''

--- a/snakemake/include/dic-docsegalign/Snakefile
+++ b/snakemake/include/dic-docsegalign/Snakefile
@@ -141,22 +141,24 @@ rule dic_docsegalign_aligndocumentsBitextor:
 ### SEGALIGN ####################################################
 # HUNALIGN ######################################################
 
+docalign_str = "" # Default: externalMT as docalign
+
+if DOCALIGN == "DIC":
+    docalign_str = "bitextor."
+
 rule dic_docsegalign_matches2hunalign:
     input:
-        indices=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.bitextor.06_01.matches',
+        indices=f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.{docalign_str}06_01.matches',
         plain1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/sentences.gz',
         plain2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/sentences.gz',
         url_l1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/url.gz',
         url_l2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/url.gz',
         tok1=f'{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/tokenised.gz',
         tok2=f'{DATADIR}/shards/{TRG_LANG}/{{shard}}/{{trg_batch}}/tokenised.gz',
-    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.hunalign.docalign.bitextor.06_02.matches.xz',
+    output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.hunalign.docalign.{docalign_str}06_02.matches.xz',
     params:
-        #c1=lambda wildcards: 1 if wildcards.docalignext == 'bitextor' else 2,
-        #c2=lambda wildcards: 2 if wildcards.docalignext == 'bitextor' else 3
-        # TODO are there other doc. aligners which should work with hugnalign?
-        c1=1,
-        c2=2
+        c1=1 if DOCALIGN == "DIC" else 2,
+        c2=2 if DOCALIGN == "DIC" else 3
     shell: '''
         cut -f {params.c1},{params.c2} {input.indices} \
             | LC_ALL=C sort -nk1 \
@@ -192,6 +194,7 @@ rule dic_docsegalign_alignsegments_hunalign:
     output: f'{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.hunalign.06_02.segalign.xz'
     shell: '''
         xzcat -T 0 {input.hunalign_matches} \
-            | {PROFILING} {BITEXTOR}/bitextor-align-segments.py -d {input.hunaligndic} -t {TMPDIR} --hunalign-dir "{BITEXTOR}/hunalign/src/hunalign" \
+            | {PROFILING} {BITEXTOR}/bitextor-align-segments.py -d {input.hunaligndic} -t {TMPDIR} \
+                --hunalign-dir "{BITEXTOR}/hunalign/src/hunalign" --hunalign-thresh {SEGALIGN_THRESHOLD} \
             | xz -T 0 > {output}
         '''

--- a/snakemake/include/dic-generation/Snakefile
+++ b/snakemake/include/dic-generation/Snakefile
@@ -1,0 +1,238 @@
+
+import os
+import gzip
+
+#################### TRAIN BILINGUAL DICTIONARIES #############################
+
+#Temporal directories for generated data
+mgizaModelDir = f"{TRANSIENT}/tempgizamodel.{SRC_LANG}-{TRG_LANG}"
+preprocCorpusDir = f"{TRANSIENT}/tempcorpuspreproc.{SRC_LANG}-{TRG_LANG}"
+
+if "initCorpusTrainingPrefix" in config:
+    trainPrefixes=config["initCorpusTrainingPrefix"]
+else:
+    trainPrefixes=None
+
+if "mkcls" in config and config["mkcls"]:
+    MKCLS="/mgiza/mgizapp/inst/mkcls"
+else:
+    MKCLS="/clustercat/bin/mkcls"
+
+#################################################################
+### RULES #######################################################
+
+rule dic_generation_tokenize_file_l1:
+    input: expand("{dataset}.{lang}.xz", dataset=trainPrefixes, lang=SRC_LANG)
+    output: f"{preprocCorpusDir}/corpus.tok.{SRC_LANG}.xz"
+    shell: '''
+        mkdir -p {preprocCorpusDir}
+        xzcat -T 0 -f {input} | sed \"s/&apos;/'/g\" | sed 's/&quot;/\"/g' | sed 's/&amp;/\&/g' | {WORDTOK1} | xz -T 0 > {output}
+        '''
+
+rule dic_generation_tokenize_file_l2:
+    input: expand("{dataset}.{lang}.xz", dataset=trainPrefixes, lang=TRG_LANG)
+    output: f"{preprocCorpusDir}/corpus.tok.{TRG_LANG}.xz"
+    shell: '''
+        mkdir -p {preprocCorpusDir}
+        xzcat -T 0 -f {input} | sed \"s/&apos;/'/g\" | sed 's/&quot;/\"/g' | sed 's/&amp;/\&/g' | {WORDTOK2} | xz -T 0 > {output}
+        '''
+
+rule dic_generation_lowercase:
+    input: "{prefix}.tok.{lang}.xz"
+    output: "{prefix}.tok.low.{lang}"
+    shell: '''
+        xzcat {input} | {PROFILING} {BITEXTOR}/preprocess/moses/tokenizer/lowercase.perl > {output}
+        '''
+
+rule dic_generation_clean:
+    input:
+        f"{{prefix}}.tok.low.{SRC_LANG}",
+        f"{{prefix}}.tok.low.{TRG_LANG}"
+    output:
+        f"{{prefix}}.clean.{SRC_LANG}",
+        f"{{prefix}}.clean.{TRG_LANG}"
+    shell: '''
+        {PROFILING} perl {BITEXTOR}/utils/clean-corpus-n.perl {wildcards.prefix}.tok.low \
+            {SRC_LANG} {TRG_LANG} {wildcards.prefix}.clean 1 80 {wildcards.prefix}.lines-retained
+        '''
+
+rule dic_generation_mkcls:
+    input: f"{preprocCorpusDir}/corpus.clean.{{lang}}"
+    output: f"{mgizaModelDir}/corpus.{{lang}}.vcb.classes"
+    priority: 40
+
+    shell: '''
+        {PROFILING} {BITEXTOR}{MKCLS} -c50 -n2 -p{input} -V{output} opt 2> /dev/null > /dev/null
+        '''
+
+rule dic_generation_plain2snt:
+    input:
+        l1=f"{preprocCorpusDir}/corpus.clean.{SRC_LANG}",
+        l2=f"{preprocCorpusDir}/corpus.clean.{TRG_LANG}",
+    output:
+        snt_2_1=f"{mgizaModelDir}/corpus.{TRG_LANG}-{SRC_LANG}-int-train.snt",
+        snt_1_2=f"{mgizaModelDir}/corpus.{SRC_LANG}-{TRG_LANG}-int-train.snt",
+        vcb1=f"{mgizaModelDir}/corpus.{SRC_LANG}.vcb",
+        vcb2=f"{mgizaModelDir}/corpus.{TRG_LANG}.vcb",
+    priority: 40
+    shell: '''
+        mkdir -p {mgizaModelDir}
+        {BITEXTOR}/mgiza/mgizapp/bin/plain2snt {input.l1} {input.l2} 2> /dev/null > /dev/null
+        mv {preprocCorpusDir}/corpus.clean.{SRC_LANG}_corpus.clean.{TRG_LANG}.snt {output.snt_2_1}
+        mv {preprocCorpusDir}/corpus.clean.{TRG_LANG}_corpus.clean.{SRC_LANG}.snt {output.snt_1_2}
+        cp {preprocCorpusDir}/corpus.clean.{SRC_LANG}.vcb {output.vcb1}
+        cp {preprocCorpusDir}/corpus.clean.{TRG_LANG}.vcb {output.vcb2}
+        '''
+
+rule dic_generation_snt2cooc:
+    input:
+        vcb1="{prefix}.{l1}.vcb",
+        vcb2="{prefix}.{l2}.vcb",
+        vcb1cls="{prefix}.{l1}.vcb.classes",
+        vcb2cls="{prefix}.{l2}.vcb.classes",
+        snt="{prefix}.{l2}-{l1}-int-train.snt"
+    output: "{prefix}.{l2}-{l1}.cooc"
+    shell: '''
+        {PROFILING} {BITEXTOR}/mgiza/mgizapp/bin/snt2cooc {output} {input.vcb1} {input.vcb2} {input.snt} 2> /dev/null
+        '''
+
+rule dic_generation_mgiza:
+    input:
+        vcb1="{prefix}.{l1}.vcb",
+        vcb2="{prefix}.{l2}.vcb",
+        snt="{prefix}.{l2}-{l1}-int-train.snt",
+        cooc="{prefix}.{l2}-{l1}.cooc"
+    output: "{prefix}.{l2}-{l1}.t3.final"
+    shell: '''
+        {PROFILING} {BITEXTOR}/mgiza/mgizapp/bin/mgiza -ncpus 8 -CoocurrenceFile {input.cooc} -c {input.snt} \
+            -m1 5 -m2 0 -m3 3 -m4 3 -mh 5 -m5 0 -model1dumpfrequency 1 -o {wildcards.prefix}.{wildcards.l2}-{wildcards.l1} \
+            -s {input.vcb1} -t {input.vcb2} -emprobforempty 0.0 -probsmooth 1e-7 2> /dev/null > /dev/null
+        '''
+
+rule dic_generation_filter_dics:
+    input: "{prefix}.vcb"
+    output: "{prefix}.filtered.vcb"
+    shell: '''
+        cat {input} | egrep ' [^ ][^ ]+$' > {output}
+        '''
+
+rule dic_generation_gzip_freq_dic:
+    input:
+        vcb1=f"{mgizaModelDir}/corpus.{SRC_LANG}.filtered.vcb",
+        vcb2=f"{mgizaModelDir}/corpus.{TRG_LANG}.filtered.vcb",
+    output:
+        vcb1=f"{mgizaModelDir}/corpus.{SRC_LANG}.filtered.vcb.gz",
+        vcb2=f"{mgizaModelDir}/corpus.{TRG_LANG}.filtered.vcb.gz",
+    shell: '''
+        gzip -c {input.vcb1} > {output.vcb1}
+        gzip -c {input.vcb2} > {output.vcb2}
+        '''
+
+# It returns a new dictionary (it might smash a provided dictionary!)
+#Obtaining the harmonic probability of each pair of words in both directions and filtering out those with less than p=0.2; printing the dictionary
+rule dic_generation_symmetrise_dic:
+    input:
+        vcb1=f"{mgizaModelDir}/corpus.{SRC_LANG}.filtered.vcb",
+        vcb2=f"{mgizaModelDir}/corpus.{TRG_LANG}.filtered.vcb",
+        t3_1=f"{mgizaModelDir}/corpus.{SRC_LANG}-{TRG_LANG}.t3.final",
+        t3_2=f"{mgizaModelDir}/corpus.{TRG_LANG}-{SRC_LANG}.t3.final",
+    output: expand("{dic}", dic=DIC_TRAINING)
+    run:
+        if DIC != DIC_TRAINING:
+            sys.stderr.write(f"WARNING: you are going to generate a new dictionary, but you have provided one which exists and is the one that will be used. If you want to use the new dictionary, set 'dic' config option to an existant path but unexistant file\n")
+            sys.stderr.write(f"WARNING: in order to avoid replacement of {DIC}, the dictionary that is going to be created has been renamed to {DIC_TRAINING}\n")
+
+        svocabulary={}
+        tvocabulary={}
+        svcb=open(input.vcb1,"r")
+        tvcb=open(input.vcb2,"r")
+        for line in svcb:
+            item=line.strip().split(" ")
+            svocabulary[item[0]]=item[1]
+
+        for line in tvcb:
+            item=line.strip().split(" ")
+            tvocabulary[item[0]]=item[1]
+
+        t3dic={}
+        t3s=open(input.t3_1,"r")
+        t3t=open(input.t3_2,"r")
+        for line in t3t:
+            item=line.strip().split(" ")
+            if item[1] in t3dic:
+                t3dic[item[1]][item[0]]=item[2]
+            else:
+                t3dic[item[1]]={}
+                t3dic[item[1]][item[0]]=item[2]
+
+        dic=open(output[0], "wt")
+        dic.write(SRC_LANG+"\t"+TRG_LANG+"\n")
+        for line in t3s:
+            item=line.strip().split(" ")
+            if item[0] in t3dic:
+                if item[1] in t3dic[item[0]]:
+                    value1=float(t3dic[item[0]][item[1]])
+                    value2=float(item[2])
+                    hmean=2/((1/value1)+(1/value2))
+
+                    if hmean > 0.1:
+                        if item[1] in svocabulary and item[0] in tvocabulary:
+                            word1=svocabulary[item[1]]
+                            word2=tvocabulary[item[0]]
+                            if word1.isalpha() or word2.isalpha():
+                                dic.write("{0}\t{1}\n".format(word1, word2))
+        svcb.close()
+        tvcb.close()
+        t3s.close()
+        t3t.close()
+        dic.close()
+        os.sync()
+
+#Obtaining the harmonic probability of each pair of words in both directions and filtering out those with less than p=0.2; printing the dictionary
+rule dic_generation_lex_dic:
+    input:
+        vcb1=f"{mgizaModelDir}/corpus.{SRC_LANG}.filtered.vcb",
+        vcb2=f"{mgizaModelDir}/corpus.{TRG_LANG}.filtered.vcb",
+        t3_1=f"{mgizaModelDir}/corpus.{SRC_LANG}-{TRG_LANG}.t3.final",
+        t3_2=f"{mgizaModelDir}/corpus.{TRG_LANG}-{SRC_LANG}.t3.final",
+    output:
+        e2f=f"{DIC_TRAINING}.lex.e2f.gz",
+        f2e=f"{DIC_TRAINING}.lex.f2e.gz",
+    run:
+        svocabulary={}
+        tvocabulary={}
+        svcb=open(input.vcb1,"r")
+        tvcb=open(input.vcb2,"r")
+        for line in svcb:
+            item=line.strip().split(" ")
+            svocabulary[item[0]]=item[1]
+
+        for line in tvcb:
+            item=line.strip().split(" ")
+            tvocabulary[item[0]]=item[1]
+
+        t3s=open(input.t3_1,"r")
+        t3t=open(input.t3_2,"r")
+        dice2f=gzip.open(output[0], "wt")
+        dicf2e=gzip.open(output[1], "wt")
+
+        for line in t3t:
+            item=line.strip().split(" ")
+            value = float(item[2])
+            if value > 0.1:
+                if item[0] in svocabulary and item[1] in tvocabulary:
+                    dice2f.write("{0} {1} {2}\n".format(svocabulary[item[0]],tvocabulary[item[1]],item[2]))
+
+        for line in t3s:
+            item=line.strip().split(" ")
+            value = float(item[2])
+            if value > 0.1:
+                if item[1] in svocabulary and item[0] in tvocabulary:
+                    dicf2e.write("{0} {1} {2}\n".format(tvocabulary[item[0]],svocabulary[item[1]],item[2]))
+        svcb.close()
+        tvcb.close()
+        t3s.close()
+        t3t.close()
+        dice2f.close()
+        dicf2e.close()
+        os.sync()

--- a/utils/args.py
+++ b/utils/args.py
@@ -110,7 +110,7 @@ def validate_args(config):
             'tmx': {'type': 'boolean'},
             'deduped': {'type': 'boolean'},
             'biroamer': {'type': 'boolean', 'default': False},
-            'biroamerOmitRandomSentences': {'type': 'boolean', 'default': False, 'dependencies': {'biroamer': True}},
+            'biroamerOmitRandomSentences': {'type': 'boolean', 'dependencies': {'biroamer': True}},
             'biroamerMixFiles': {'type': 'list', 'check_with': isfile, 'dependencies': {'biroamer': True}},
             'biroamerImproveAlignmentCorpus': {'type': 'string', 'check_with': isfile, 'dependencies': {'biroamer': True}}
             }

--- a/utils/args.py
+++ b/utils/args.py
@@ -87,13 +87,13 @@ def validate_args(config):
             # document alignment
             'lang1': {'type': 'string'},
             'lang2': {'type': 'string'},
-            'documentAligner': {'type': 'string', 'allowed': ['DIC', 'externalMT'], 'default': 'externalMT'},
+            'documentAligner': {'type': 'string', 'allowed': ['DIC', 'externalMT'], 'default': 'externalMT', 'dependencies': {}},
             # mt
             'alignerCmd': {'type': 'string', 'dependencies': {'documentAligner': 'externalMT'}},
             'translationDirection': {'type': 'string', 'dependencies': {'documentAligner': 'externalMT'}},
             'documentAlignerThreshold': {'type': 'float', 'dependencies': {'documentAligner': 'externalMT'}},
             # dictionary
-            'dic': {'type': 'string'}, # TODO: depends on documentAligner=DIC, or sentenceAligner=hunalign, TODO: check if dictionary exists, use training subworkflow if not
+            'dic': {'type': 'string', 'dependencies': {}},
             'initCorpusTrainingPrefix': {'type': 'list'},
             'mkcls': {'type': 'boolean'},
             # sentence alignment
@@ -129,12 +129,12 @@ def validate_args(config):
     if "documentAligner" not in config or config['documentAligner'] == 'externalMT':
         schema['alignerCmd']['required'] = True
         schema['translationDirection']['allowed'] = [f'{config["lang1"]}2{config["lang2"]}', f'{config["lang2"]}2{config["lang1"]}']
-    elif "documentAligner" in config and config['documentAligner'] == 'DIC':
-        schema['dic']['required'] = True
-        schema['documentAligner']['dependencies'] = {'preprocessor': 'warc2preprocess'}
 
-        if "dic" in config and not os.path.isfile(config["dic"]):
-            schema['initCorpusTrainingPrefix']['required']=True
+        if "sentenceAligner" in config and config["sentenceAligner"] == "hunalign":
+            schema['dic']['required'] = True
+    elif config['documentAligner'] == 'DIC':
+        schema['dic']['required'] = True
+        schema['documentAligner']['dependencies']['preprocessor'] = 'warc2preprocess'
 
     if "sentenceAligner" not in config or config['sentenceAligner'] == 'bleualign':
         #schema['sentenceAligner']['dependencies'] = frozenset({'documentAligner': 'externalMT'}) # dependencies are not working because of the frozenset

--- a/utils/non_generic.py
+++ b/utils/non_generic.py
@@ -1,0 +1,65 @@
+#  This file is part of Bitextor.
+#
+#  Bitextor is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Bitextor is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Bitextor.  If not, see <https://www.gnu.org/licenses/>.
+
+# Non-generic files (used in concrete places and moments)
+
+import tldextract
+from itertools import product
+
+def create_domain_key_2_host_map(hosts):
+    key2hosts = {}
+    for host in hosts:
+        # don't merge blog sites
+        if host.find(".blogspot.") >= 0 or host.find(".wordpress.") >= 0:
+            key = host
+        else:
+            key = tldextract.extract(host).domain
+
+        if key not in key2hosts:
+            key2hosts[key] = []
+        key2hosts[key].append(host)
+    return key2hosts
+
+
+def parent_folder_2_warcs(warcs):
+    f2w = {}
+    for warc in warcs:
+        folder = warc.split('/')[-2]
+        if folder not in f2w:
+            f2w[folder] = []
+        f2w[folder].append(warc)
+    return f2w
+
+
+def get_lang_or_default(scripts_dict, language):
+    cmd = ""
+    if language in scripts_dict:
+        cmd = scripts_dict[language]
+    elif "default" in scripts_dict:
+        cmd = scripts_dict["default"]
+    return cmd
+
+
+def get_customnbp(nbp_dict, language):
+    nbp = ""
+    if language in nbp_dict:
+        nbp = nbp_dict[language]
+    return nbp
+
+def get_mt_docalign_inputs(src_batches, trg_batches):
+    # product( [[shard, batch], [shard, batch], ...], [[shard, batch], [shard, batch], ...] )
+    iterator = product( [batch.split('/')[-2:] for batch in src_batches], [batch.split('/')[-2:] for batch in trg_batches] )
+    # each item -> (shard, (src_batch, trg_batch))
+    return [(src_shard, (src_batch, trg_batch)) for ((src_shard, src_batch), (trg_shard, trg_batch)) in iterator if src_shard == trg_shard]


### PR DESCRIPTION
* Biroamer has been integrated (new submodule).
* Bicleaner training has been integrated back from master.
* Dic-based docalign and hunalign has been integrated back from master.
* Removed utils.smk because it was not necessary to be an snakefile. Now is a python file (utils/args.py). Other functions from the same file have been moved (utils/non_generic.py).
* Dictionary now is not removed when 'dic' config option exists and a bicleaner model is trained.
* Fix problem in shards which when empty or near empty warcs were provided, the preprocessor was not being taken into consideration (is needed because the path where we have to create files changes depending on the preprocessor).
* Other minnor fixes.

Changes from previous pull request:
* Arguments dependencies are being better handled (fixed giawarc incompatibility and added new rules to biroamer).
* Some places in post processing were being evaluated with document aligner instead of sentence aligner (before the pull request was done, the checking was being performed with sentence aligner). Mainly "deferred" and at the end of segalign (rule "split_segalign").
* "raw" rule was not working when bicleaner was disabled because hunalign had not been contemplated.
* Other minnor changes (again).