### PR TITLE
Fix docalign CMakeLists.txt ICU include

### DIFF
--- a/document-aligner/CMakeLists.txt
+++ b/document-aligner/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(ICU REQUIRED COMPONENTS
 include_directories(
   ${PROJECT_SOURCE_DIR}
   ${Boost_INCLUDE_DIRS}
-  ${ICU_INCLUDE_DIR}
+  ${ICU_INCLUDE_DIRS}
 )
 
 if (PREPROCESS_PATH)


### PR DESCRIPTION
While doing tests with Conda in an isolated environment, could not build Bitextor. The error which was being displayed is:
```
cd document-aligner && cmake -DBUILD_TESTING=OFF . && make
// ...
-- Found ICU: $PREFIX/include (found version "58.2")
// ...
[ 11%] Building CXX object preprocess-bin/util/CMakeFiles/preprocess_util.dir/compress.cc.o
In file included from /home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/document-aligner/../preprocess/util/fake_ostream.hh:6,
                 from /home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/document-aligner/../preprocess/util/string_stream.hh:4,
                 from /home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/document-aligner/../preprocess/util/exception.hh:4,
                 from /home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/document-aligner/../preprocess/util/compress.hh:4,
                 from /home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/preprocess/util/compress.cc:1:
/home/cristian/miniconda3/envs/bitextor/envs/bitextor/conda-bld/bitextor_1605527962380/work/bitextor/document-aligner/../preprocess/util/string_piece.hh:58:10: fatal error: unicode/stringpiece.h: No such file or directory
   58 | #include <unicode/stringpiece.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```

After researching (manual checking about ICU and following cmake and makefiles' files), this error leaded me to `document-aligner/CMakeLists.txt` and the line about `ICU_INCLUDE_DIR`, which is missing an S (https://cmake.org/cmake/help/latest/module/FindICU.html and `CMakeLists.txt` in `preprocess` submodule). The problem is related to the auto-generated file `document-aligner/preprocess-bin/util/CMakeFiles/preprocess_util.dir/flags.make`, which is not including ICU dir in CXX path.