### PR TITLE
Fix CMakeLists.txt CMAKE_CXX_FLAGS

### DIFF
--- a/document-aligner/CMakeLists.txt
+++ b/document-aligner/CMakeLists.txt
@@ -6,7 +6,7 @@ project(document-aligner)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "-Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "-Ofast")
 set(CMAKE_CXX_FLAGS_DEBUG "-Wextra -g")
 


### PR DESCRIPTION
As I said in #187 , I though that all the problem with ICU libraries was related to `ICU_INCLUDE_DIRS` in the `CMakeLists.txt`. I didn't check if that was the only problem in the isolated environment where I'm trying to build Bitextor. After testing, I've found out that the real problem was that the `CMAKE_CXX_FLAGS` which Conda is using is being removed in `CmakeLists.txt`. After try to set `CMAKE_CXX_FLAGS` to `${CMAKE_CXX_FLAGS} -Wall` the build doesn't fail because now ICU headers are found (Conda use its own ICU headers and libs, which are not in the default system directory, and until now hasn't failed because ICU headers have always been installed in the user's filesystem).

This change shouldn't be dangerous since `CMAKE_CXX_FLAGS` is optional, and it allows to other environments like Conda to handle CMake as it does. If an user modifies this environment variable, is not problem of Bitextor if the build fails.

By the way, I have checked to compile a minimum file with `-Wall -Wall` and there wasn't any error nor warning.