### PR TITLE
Hunalign submodule replaced with official repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = mgiza
 	url = https://github.com/moses-smt/mgiza
 	ignore = dirty
-[submodule "hunalign"]
-	path = hunalign
-	url = https://github.com/bitextor/hunalign
-	ignore = dirty
 [submodule "bicleaner"]
 	path = bicleaner
 	url = https://github.com/bitextor/bicleaner
@@ -33,3 +29,8 @@
 [submodule "biroamer"]
 	path = biroamer
 	url = https://github.com/bitextor/biroamer.git
+	ignore = dirty
+[submodule "hunalign"]
+	path = hunalign
+	url = https://github.com/danielvarga/hunalign
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = biroamer
 	url = https://github.com/bitextor/biroamer.git
 	ignore = dirty
+[submodule "hunalign"]
+	path = hunalign
+	url = https://github.com/bitextor/hunalign
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,3 @@
 	path = biroamer
 	url = https://github.com/bitextor/biroamer.git
 	ignore = dirty
-[submodule "hunalign"]
-	path = hunalign
-	url = https://github.com/danielvarga/hunalign
-	ignore = dirty


### PR DESCRIPTION
Current Hunaliagn submodule replaced by official repo. The official repo uses "-utf" flag as default, so it is not needed to set it in `bitextor-align-segments.py`. Differences between current Hunalign repo and official have been tested and same results have been obtained when "-utf" flag matches both versions (with and without).

Flag "dirty" added to Biroamer submodule.