### PR TITLE
Bicleaner and dictionary generation configuration changes

### DIFF
--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -289,9 +289,9 @@ if "bifixer" in config and config["bifixer"]:
 
 if "aggressiveDedup" in config and not config["aggressiveDedup"]:
     AGGRESSIVE_DEDUP = ""
-if "bicleaner" in config:
+if "bicleaner" in config and config["bicleaner"]:
     BICLEANER = True
-    BICLEANER_MODEL = config["bicleaner"]
+    BICLEANER_MODEL = config["bicleanerModel"]
     BICLEANER_FIELDS = ["bicleaner"]
 if "bicleanerThreshold" in config:
     BICLEANER_THRESHOLD = config["bicleanerThreshold"]

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -8,8 +8,6 @@ from bitextor.utils.common import (
     open_xz_or_gzip_or_plain,
     get_all_ppids,
     snake_no_more_race_get_pgid,
-    snake_no_more_race_get,
-    snake_no_more_race_set,
     duration_to_seconds,
 )
 
@@ -219,29 +217,9 @@ except:
     pass
 
 DIC = None
-DIC_TRAINING = None
 
 if "dic" in config:
     DIC = config["dic"]
-    DIC_TRAINING = DIC
-    dic_training_file_path = f"{TMPDIR}/dic_training.value"
-    dic_training_file = False
-
-    value = snake_no_more_race_get(dic_training_file_path)
-
-    if value is not None:
-        DIC_TRAINING = value
-        dic_training_file = True
-
-    if (
-        not dic_training_file
-        and os.path.isfile(DIC)
-        and ("bicleanerCorpusTrainingPrefix" in config and "initCorpusTrainingPrefix" in config)
-    ):
-        DIC_TRAINING += ".generated"
-
-    # Create file with DIC_TRAINING value in order to avoid that, when DAG is reevaluated, changes the value of the variable
-    snake_no_more_race_set(dic_training_file_path, DIC_TRAINING)
 
 #################################################################
 # SEGALIGN
@@ -1250,12 +1228,10 @@ rule bicleaner_train_model:
     input:
         corpusl1=expand("{dataset}.{lang}.xz", dataset=BICLEANER_TRAIN_PREFIXES, lang=LANG1),
         corpusl2=expand("{dataset}.{lang}.xz", dataset=BICLEANER_TRAIN_PREFIXES, lang=LANG2),
-        e2f=f"{DIC_TRAINING}.lex.e2f.gz",
-        f2e=f"{DIC_TRAINING}.lex.f2e.gz",
+        e2f=f"{DIC}.lex.e2f.gz",
+        f2e=f"{DIC}.lex.f2e.gz",
         vcb1=f"{mgizaModelDir}/corpus.{LANG1}.filtered.vcb.gz",
         vcb2=f"{mgizaModelDir}/corpus.{LANG2}.filtered.vcb.gz",
-        dic=f"{DIC_TRAINING}",  # If DIC != DIC_TRAINING, DIC_TRAINING will be generated but not used because of this input
-        # This input makes the dictionary to be generated (without it, statistical info would be generated but not the dic)
     output:
         model=BICLEANER_MODEL,
     shell:
@@ -1267,7 +1243,6 @@ rule bicleaner_train_model:
         lines=$(cat $training | wc -l)
         trainlines=$(echo \"$lines*4/10\" | bc)
         testlines=$(echo \"($lines-2*$trainlines)/2\" | bc)
-        # Parameters for good/bad examples have been removed -> now the whole file is being used (https://github.com/bitextor/bicleaner/commit/cdd1bc03928701884cd42ffac4b602220ec3e732)
         {PROFILING} bicleaner-train $training -S "{WORDTOK1}" -T "{WORDTOK2}" --treat_oovs --normalize_by_length -s {LANG1} -t {LANG2} -d {input.e2f} -D {input.f2e} -f {input.vcb1} -F {input.vcb2} -c $DIR/{LANG1}-{LANG2}.classifier -m {BICLEANER_MODEL} --classifier_type random_forest
         rm $training
         """

--- a/bitextor/rules/dicgeneration.smk
+++ b/bitextor/rules/dicgeneration.smk
@@ -165,16 +165,8 @@ rule dic_generation_symmetrise_dic:
         t3_1=f"{mgizaModelDir}/corpus.{SRC_LANG}-{TRG_LANG}.t3.final",
         t3_2=f"{mgizaModelDir}/corpus.{TRG_LANG}-{SRC_LANG}.t3.final",
     output:
-        expand("{dic}", dic=DIC_TRAINING),
+        expand("{dic}", dic=DIC),
     run:
-        if DIC != DIC_TRAINING:
-            sys.stderr.write(
-                f"WARNING: you are going to generate a new dictionary, but you have provided one which exists and is the one that will be used. If you want to use the new dictionary, set 'dic' config option to an existant path but unexistant file\n"
-            )
-            sys.stderr.write(
-                f"WARNING: in order to avoid replacement of {DIC}, the dictionary that is going to be created has been renamed to {DIC_TRAINING}\n"
-            )
-
         svocabulary = {}
         tvocabulary = {}
         svcb = open(input.vcb1, "r")
@@ -230,8 +222,8 @@ rule dic_generation_lex_dic:
         t3_1=f"{mgizaModelDir}/corpus.{SRC_LANG}-{TRG_LANG}.t3.final",
         t3_2=f"{mgizaModelDir}/corpus.{TRG_LANG}-{SRC_LANG}.t3.final",
     output:
-        e2f=f"{DIC_TRAINING}.lex.e2f.gz",
-        f2e=f"{DIC_TRAINING}.lex.f2e.gz",
+        e2f=f"{DIC}.lex.e2f.gz",
+        f2e=f"{DIC}.lex.f2e.gz",
     run:
         svocabulary = {}
         tvocabulary = {}

--- a/bitextor/utils/args.py
+++ b/bitextor/utils/args.py
@@ -46,6 +46,10 @@ def isduration(field, value, error):
         error(field, f"format is an integer followed by a single letter suffix")
 
 
+def istrue(field, value, error):
+    if value != True:
+        error(field, f'{value} is not True')
+
 def validate_args(config):
     schema = {
         # required parameters
@@ -156,6 +160,7 @@ def validate_args(config):
         'documentAlignerThreshold': {'type': 'float', 'dependencies': {'documentAligner': 'externalMT'}},
         # dictionary
         'dic': {'type': 'string', 'dependencies': {}},
+        'generateDic': {'type': 'boolean', 'default': False, 'dependencies': {}},
         'initCorpusTrainingPrefix': {'type': 'list'},
         # sentence alignment
         'sentenceAligner': {'type': 'string', 'allowed': ['bleualign', 'hunalign'], 'default': 'bleualign'},
@@ -167,7 +172,8 @@ def validate_args(config):
         'aggressiveDedup': {'type': 'boolean', 'dependencies': {'bifixer': True}},
         # cleaning
         'bicleaner': {'type': 'boolean', 'default': False},
-        'bicleanerModel': {'type': 'string', 'check_with': isfile, 'dependencies': {'bicleaner': True}},
+        'bicleanerModel': {'type': 'string', 'dependencies': {'bicleaner': True}},
+        'bicleanerGenerateModel': {'type': 'boolean', 'default': False},
         'bicleanerThreshold': {'type': 'float'},
         'bicleanerCorpusTrainingPrefix': {'type': 'list'},
         # elrc metrics
@@ -214,16 +220,25 @@ def validate_args(config):
         if "sentenceAligner" in config and config["sentenceAligner"] == "hunalign":
             schema['dic']['required'] = True
 
+            if ('dic' in config and not os.path.isfile(os.path.expanduser(config['dic']))):
+                schema['generateDic']['required'] = True
+                schema['generateDic']['check_with'] = istrue
+
     elif config['documentAligner'] == 'DIC':
         schema['dic']['required'] = True
         schema['documentAligner']['dependencies']['preprocessor'] = ['warc2preprocess', 'warc2text']
 
         if config['preprocessor'] == 'warc2text':
             config['writeHTML'] = True
+        if ('dic' in config and not os.path.isfile(os.path.expanduser(config['dic']))):
+                schema['generateDic']['required'] = True
+                schema['generateDic']['check_with'] = istrue
+
+    if "generateDic" in config and config["generateDic"]:
+        schema['dic']['required'] = True
+        schema['initCorpusTrainingPrefix']['required'] = True
 
     if "sentenceAligner" not in config or config['sentenceAligner'] == 'bleualign':
-        # schema['sentenceAligner']['dependencies'] = frozenset({'documentAligner': 'externalMT'})
-        # dependencies are not working because of the frozenset
         schema['sentenceAligner']['dependencies'] = {'documentAligner': 'externalMT'}
 
     if "deferred" in config:
@@ -234,23 +249,21 @@ def validate_args(config):
         schema['until']['allowed'].append('bifixer')
         schema['parallelWorkers']['allowed'].append('bifixer')
 
-    if 'bicleaner' in config:
+    if 'bicleaner' in config and config['bicleaner']:
         schema['until']['allowed'].append('bicleaner')
         schema['parallelWorkers']['allowed'].append('bicleaner')
         schema['bicleanerModel']['required'] = True
 
-        # TODO use a specific config variable for this
-        #if not os.path.isfile(os.path.expanduser(config['bicleaner'])):
-        #    schema['bicleanerCorpusTrainingPrefix']['required'] = True
-        #    schema['initCorpusTrainingPrefix']['required'] = True
-        #    schema['dic']['required'] = True
+        if 'bicleanerGenerateModel' in config and config['bicleanerGenerateModel']:
+            schema['dic']['required'] = True
+            schema['bicleanerCorpusTrainingPrefix']['required'] = True
+            schema['initCorpusTrainingPrefix']['required'] = True
 
-    if 'dic' in config and not os.path.isfile(os.path.expanduser(config['dic'])):
-        # if 'dic' in config and does not exist, we need to generate a new dictionary
-        schema['initCorpusTrainingPrefix']['required'] = True
-
-    if 'initCorpusTrainingPrefix' in config:
-        schema['dic']['required'] = True
+            if ('dic' in config and not os.path.isfile(os.path.expanduser(config['dic']))):
+                schema['generateDic']['required'] = True
+                schema['generateDic']['check_with'] = istrue
+        else:
+            schema['bicleanerModel']['check_with'] = isfile
 
     if 'until' in config and (config['until'] == 'filter' or config['until'] == 'bifixer'):
         print(

--- a/bitextor/utils/args.py
+++ b/bitextor/utils/args.py
@@ -165,12 +165,17 @@ def validate_args(config):
         'bifixer': {'type': 'boolean', 'default': False},
         # mark near duplicates as duplicates
         'aggressiveDedup': {'type': 'boolean', 'dependencies': {'bifixer': True}},
-        'bicleaner': {'type': 'string'},
-        'bicleanerThreshold': {'type': 'float', 'dependencies': 'bicleaner'},
+        # cleaning
+        'bicleaner': {'type': 'boolean', 'default': False},
+        'bicleanerModel': {'type': 'string', 'check_with': isfile, 'dependencies': {'bicleaner': True}},
+        'bicleanerThreshold': {'type': 'float'},
         'bicleanerCorpusTrainingPrefix': {'type': 'list'},
+        # elrc metrics
         'elrc': {'type': 'boolean'},
+        # tmx
         'tmx': {'type': 'boolean'},
         'deduped': {'type': 'boolean'},
+        # roam
         'biroamer': {'type': 'boolean', 'default': False},
         'biroamerOmitRandomSentences': {'type': 'boolean', 'dependencies': {'biroamer': True}},
         'biroamerMixFiles': {'type': 'list', 'check_with': isfile, 'dependencies': {'biroamer': True}},
@@ -232,11 +237,13 @@ def validate_args(config):
     if 'bicleaner' in config:
         schema['until']['allowed'].append('bicleaner')
         schema['parallelWorkers']['allowed'].append('bicleaner')
+        schema['bicleanerModel']['required'] = True
 
-        if not os.path.isfile(os.path.expanduser(config['bicleaner'])):
-            schema['bicleanerCorpusTrainingPrefix']['required'] = True
-            schema['initCorpusTrainingPrefix']['required'] = True
-            schema['dic']['required'] = True
+        # TODO use a specific config variable for this
+        #if not os.path.isfile(os.path.expanduser(config['bicleaner'])):
+        #    schema['bicleanerCorpusTrainingPrefix']['required'] = True
+        #    schema['initCorpusTrainingPrefix']['required'] = True
+        #    schema['dic']['required'] = True
 
     if 'dic' in config and not os.path.isfile(os.path.expanduser(config['dic'])):
         # if 'dic' in config and does not exist, we need to generate a new dictionary

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -331,11 +331,13 @@ A number of pre-trained models for Bicleaner are available [here](https://github
 The options required to make it work are:
 
 ```yaml
-bicleaner: /home/user/bicleaner-model/en-fr/training.en-fr.yaml
+bicleaner: True
+bicleanerModel: /home/user/bicleaner-model/en-fr/training.en-fr.yaml
 bicleanerThreshold: 0.6
 ```
 
-* `bicleaner`: path to the YAML configuration file of a pre-trained model
+* `bicleaner`: use Bicleaner to filter out pairs of segments
+* `bicleanerModel`: path to the YAML configuration file of a pre-trained model
 * `bicleanerThreshold`: threshold to filter low-confidence segment pairs, accepts values in [0,1] range; default is 0.0 (no filtering). It is recommended to set it to values in [0.5,0.7]
 
 If the Bicleaner model is not available, the pipeline will try to train one automatically from the data provided through the config file options `initCorpusTrainingPrefix` and `bicleanerCorpusTrainingPrefix`:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -279,9 +279,10 @@ dic: /home/user/en-fr.dic
 
 Option `dic` specifies the path to the bilingual lexicon to be used for document alignment. This dictionary should have words in `lang1` in the first column, and `lang2` in the second one.
 
-If the lexicon specified does not exist, the pipeline will try to build it using a parallel corpus provided through the variable `initCorpusTrainingPrefix` using `mgiza` tools:
+If the lexicon specified does not exist, you can specify the option `generateDic` in order to build it using a provided parallel corpus through the variable `initCorpusTrainingPrefix` using `mgiza` tools:
 
 ```yaml
+generateDic: True
 documentAligner: DIC
 initCorpusTrainingPrefix: ['/home/user/Europarl.en-fr.train']
 ```
@@ -340,14 +341,15 @@ bicleanerThreshold: 0.6
 * `bicleanerModel`: path to the YAML configuration file of a pre-trained model
 * `bicleanerThreshold`: threshold to filter low-confidence segment pairs, accepts values in [0,1] range; default is 0.0 (no filtering). It is recommended to set it to values in [0.5,0.7]
 
-If the Bicleaner model is not available, the pipeline will try to train one automatically from the data provided through the config file options `initCorpusTrainingPrefix` and `bicleanerCorpusTrainingPrefix`:
+If the Bicleaner model is not available, you can specify the option `bicleanerGenerateModel` in order to train one automatically from the data provided through the config file options `initCorpusTrainingPrefix` and `bicleanerCorpusTrainingPrefix`:
 
 ```yaml
+bicleanerGenerateModel: True
 initCorpusTrainingPrefix: ['/home/user/Europarl.en-fr.train']
 bicleanerCorpusTrainingPrefix: ['/home/user/RF.en-fr']
 ```
 
-* `initCorpusTrainingPrefix`: prefix to parallel corpus (see [Variables for bilingual lexica](#using-bilingual-lexica)) that will be used to train statistical dictionaries which are part of the Bicleaner model. If `dic` is provided and does not exist, it will be generated; if `dic` is provided and eixts, it should not be replaced, and '`dic`.generated' will be created. If `hunalign` is used, the provided `dic` will be prioritised instead of the generated one
+* `initCorpusTrainingPrefix`: prefix to parallel corpus (see [Variables for bilingual lexica](#using-bilingual-lexica)) that will be used to train statistical dictionaries which are part of the Bicleaner model. If `dic` is provided and does not exist, you will need to generate one with `generateDic`. Even if `dic` exists because you downloaded it, the whole process of generating it might be carried out since what is really necessary to build the model is the statistical information from the dictionary, what might not be available if you downloaded it
 
 * `bicleanerCorpusTrainingPrefix`: prefix to the parallel corpus that will be used to train the regressor that obtains the confidence score in Bicleaner
 

--- a/docs/config/basic.yaml
+++ b/docs/config/basic.yaml
@@ -31,7 +31,8 @@ sentenceAlignerThreshold: 0.1
 
 # CLEANING
 bifixer: true
-bicleaner: ~/bicleaner-model/en-fr/en-fr.yaml
+bicleaner: True
+bicleanerModel: ~/bicleaner-model/en-fr/en-fr.yaml
 bicleanerThreshold: 0.5
 biroamer: false
 

--- a/tests/run-tests-min.sh
+++ b/tests/run-tests-min.sh
@@ -105,7 +105,7 @@ ln -s "${WORK}/data/warc/clipped/greenpeaceaa.warc.gz" "${WORK}/data/warc/greenp
             dataDir="${WORK}/data/data-mt-en-fr" transientDir="${WORK}/transient-mt-en-fr" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
-            bicleaner="${BICLEANER}/en-fr/en-fr.yaml" deferred=True tmx=True \
+            bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" deferred=True tmx=True \
         &> "${WORK}/reports/10-mt-en-fr.report"
     annotate_and_echo_info 10 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mt-output-en-fr/en-fr.sent.gz)"
 ) &
@@ -117,7 +117,7 @@ ln -s "${WORK}/data/warc/clipped/greenpeaceaa.warc.gz" "${WORK}/data/warc/greenp
             dataDir="${WORK}/data/data-en-fr" transientDir="${WORK}/transient-en-fr" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
-            bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+            bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
         &> "${WORK}/reports/20-en-fr.report"
     annotate_and_echo_info 20 "$?" "$(get_nolines ${WORK}/permanent/bitextor-output-en-fr/en-fr.sent.gz)"
 ) &
@@ -134,7 +134,7 @@ wait
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
-            bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+            bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
         &> "${WORK}/reports/60-mtdb-en-fr.report"
     annotate_and_echo_info 60 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mtdb-output-en-fr/en-fr.sent.gz)"
 ) &
@@ -158,7 +158,7 @@ wait
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
-            bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.0 \
+            bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.0 \
             deferred=False bifixer=True aggressiveDedup=True tmx=True deduped=True biroamer=False \
         &> "${WORK}/reports/101-mto2-en-fr.report"
     annotate_and_echo_info 101 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mto2-output-en-fr/en-fr.sent.gz)"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -113,7 +113,7 @@ tests-mt()
                 dataDir="${WORK}/data/data-mt-en-fr" transientDir="${WORK}/transient-mt-en-fr" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
-                bicleaner="${BICLEANER}/en-fr/en-fr.yaml" deferred=True tmx=True \
+                bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" deferred=True tmx=True \
             &> "${WORK}/reports/10-mt-en-fr.report"
         annotate_and_echo_info 10 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mt-output-en-fr/en-fr.sent.gz)"
     ) &
@@ -148,7 +148,7 @@ tests-db()
                 dataDir="${WORK}/data/data-en-fr" transientDir="${WORK}/transient-en-fr" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
-                bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+                bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/20-en-fr.report"
         annotate_and_echo_info 20 "$?" "$(get_nolines ${WORK}/permanent/bitextor-output-en-fr/en-fr.sent.gz)"
     ) &
@@ -167,7 +167,7 @@ tests-gendic()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+                bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/30-gendic-en-fr.report"
         annotate_and_echo_info 30 "$?" "$(get_nolines ${WORK}/permanent/bitextor-gendic-output-en-fr/en-fr.sent.gz)"
         echo "Removing '${WORK}/transient-gendic-en-fr' ($(du -sh ${WORK}/transient-gendic-en-fr | awk '{print $1}'))"
@@ -180,7 +180,7 @@ tests-gendic()
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                     documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                    bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+                    bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/30-gendic-en-fr.report"
             annotate_and_echo_info 30 "$?" "$(get_nolines ${WORK}/permanent/bitextor-gendic-output-en-fr/en-fr.sent.gz)"
         ) &
@@ -200,7 +200,8 @@ tests-genbicleaner()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                bicleaner="${BICLEANER}/new/new-en-fr.yaml" bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
+                bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" \
+                bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                 bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/40-genbicleaner-en-fr.report"
         annotate_and_echo_info 40 "$?" "$(get_nolines ${WORK}/permanent/bitextor-genbicleaner-output-en-fr/en-fr.sent.gz)" && \
@@ -215,7 +216,8 @@ tests-genbicleaner()
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                     documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                    bicleaner="${BICLEANER}/new/new-en-fr.yaml" bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
+                    bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" \
+                    bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                     bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/40-genbicleaner-en-fr.report"
             annotate_and_echo_info 40 "$?" "$(get_nolines ${WORK}/permanent/bitextor-genbicleaner-output-en-fr/en-fr.sent.gz)" && \
@@ -238,7 +240,8 @@ tests-gendic-genbicleaner()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                bicleaner="${BICLEANER}/new-new/new-new-en-fr.yaml" bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
+                bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" \
+                bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                 bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/50-gendicbicleaner-en-fr.report"
         annotate_and_echo_info 50 "$?" "$(get_nolines ${WORK}/permanent/bitextor-gendicbicleaner-output-en-fr/en-fr.sent.gz)"
@@ -252,7 +255,8 @@ tests-gendic-genbicleaner()
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                     documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                    bicleaner="${BICLEANER}/new-new/new-new-en-fr.yaml" bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
+                    bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" \
+                    bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                     bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/50-gendicbicleaner-en-fr.report"
             annotate_and_echo_info 50 "$?" "$(get_nolines ${WORK}/permanent/bitextor-gendicbicleaner-output-en-fr/en-fr.sent.gz)"
@@ -270,7 +274,7 @@ tests-mt-db()
                 preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
-                bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
+                bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/60-mtdb-en-fr.report"
         annotate_and_echo_info 60 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mtdb-output-en-fr/en-fr.sent.gz)"
     ) &
@@ -296,7 +300,7 @@ tests-others()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
-                bicleaner="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.0 \
+                bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.0 \
                 deferred=False bifixer=True aggressiveDedup=True tmx=True deduped=True biroamer=True \
             &> "${WORK}/reports/101-mto2-en-fr.report"
         annotate_and_echo_info 101 "$?" "$(get_nolines ${WORK}/permanent/bitextor-mto2-output-en-fr/en-fr.sent.gz)"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -165,7 +165,7 @@ tests-gendic()
             --config profiling=True permanentDir="${WORK}/permanent/bitextor-gendic-output-en-fr" \
                 dataDir="${WORK}/data/data-gendic-en-fr" transientDir="${WORK}/transient-gendic-en-fr" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" sentenceAligner="hunalign" \
+                documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" generateDic=True sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
                 bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/30-gendic-en-fr.report"
@@ -178,7 +178,7 @@ tests-gendic()
                 --config profiling=True permanentDir="${WORK}/permanent/bitextor-gendic-output-en-fr" \
                     dataDir="${WORK}/data/data-gendic-en-fr" transientDir="${WORK}/transient-gendic-en-fr" \
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                    documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" sentenceAligner="hunalign" \
+                    documentAligner="DIC" dic="${WORK}/permanent/new-en-fr.dic" generateDic=True sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
                     bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/30-gendic-en-fr.report"
@@ -198,9 +198,9 @@ tests-genbicleaner()
             --config profiling=True permanentDir="${WORK}/permanent/bitextor-genbicleaner-output-en-fr" \
                 dataDir="${WORK}/data/data-genbicleaner-en-fr" transientDir="${WORK}/transient-genbicleaner-en-fr" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
+                documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" generateDic=False sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" \
+                bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" bicleanerGenerateModel=True \
                 bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                 bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/40-genbicleaner-en-fr.report"
@@ -214,9 +214,9 @@ tests-genbicleaner()
                 --config profiling=True permanentDir="${WORK}/permanent/bitextor-genbicleaner-output-en-fr" \
                     dataDir="${WORK}/data/data-genbicleaner-en-fr" transientDir="${WORK}/transient-genbicleaner-en-fr" \
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                    documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" \
+                    documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" generateDic=False sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                    bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" \
+                    bicleaner=True bicleanerModel="${BICLEANER}/new/new-en-fr.yaml" bicleanerGenerateModel=True \
                     bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                     bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/40-genbicleaner-en-fr.report"
@@ -238,9 +238,9 @@ tests-gendic-genbicleaner()
             --config profiling=True permanentDir="${WORK}/permanent/bitextor-gendicbicleaner-output-en-fr" \
                 dataDir="${WORK}/data/data-gendicbicleaner-en-fr" transientDir="${WORK}/transient-gendicbicleaner-en-fr" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" sentenceAligner="hunalign" \
+                documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" generateDic=True sentenceAligner="hunalign" \
                 initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" \
+                bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" bicleanerGenerateModel=True \
                 bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                 bicleanerThreshold=0.1 deferred=False tmx=True \
             &> "${WORK}/reports/50-gendicbicleaner-en-fr.report"
@@ -253,9 +253,9 @@ tests-gendic-genbicleaner()
                 --config profiling=True permanentDir="${WORK}/permanent/bitextor-gendicbicleaner-output-en-fr" \
                     dataDir="${WORK}/data/data-gendicbicleaner-en-fr" transientDir="${WORK}/transient-gendicbicleaner-en-fr" \
                     warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
-                    documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" sentenceAligner="hunalign" \
+                    documentAligner="DIC" dic="${WORK}/permanent/new-new-en-fr.dic" generateDic=True sentenceAligner="hunalign" \
                     initCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/Europarl/Europarl.clipped.en-fr']" \
-                    bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" \
+                    bicleaner=True bicleanerModel="${BICLEANER}/new-new/new-new-en-fr.yaml" bicleanerGenerateModel=True \
                     bicleanerCorpusTrainingPrefix="['${WORK}/data/parallel-corpus/DGT/DGT.clipped.en-fr']" \
                     bicleanerThreshold=0.1 deferred=False tmx=True \
                 &> "${WORK}/reports/50-gendicbicleaner-en-fr.report"


### PR DESCRIPTION
Main changes: Bicleaner and dictionary generation configuration options.

* `bicleaner` will enable or disable Bicleaner, and `bicleanerModel` will contain the path to the model.
* The training of a new Bicleaner model will need to be explicitly enabled with `bicleanerGenerateModel` instead of checking out if the model provided through `bicleanerModel` exists or not.
* The generation of a new dictionary will need to be set through `generateDic` instead of checking out whether the dictionary exists or not.