### PR TITLE
Paragraph identification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,6 @@
 	path = bleualign-cpp
 	url = https://github.com/bitextor/bleualign-cpp
 	ignore = dirty
-	branch = paragraph_identification
 [submodule "biroamer"]
 	path = biroamer
 	url = https://github.com/bitextor/biroamer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,7 @@
 	path = bleualign-cpp
 	url = https://github.com/bitextor/bleualign-cpp
 	ignore = dirty
+	branch = paragraph_identification
 [submodule "biroamer"]
 	path = biroamer
 	url = https://github.com/bitextor/biroamer.git

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -351,6 +351,11 @@ if "preverticalsFile" in config:
         for line in f:
             PREVERTICALS.add(line.strip())
 
+# sort in order to avoid different results across executions
+HOSTS = sorted(list(HOSTS))
+WARCS = sorted(list(WARCS))
+PREVERTICALS = sorted(list(PREVERTICALS))
+
 # group hosts by domain and check their validity
 DOMAIN_2_HOSTS = create_domain_key_2_host_map(HOSTS)
 

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -766,10 +766,11 @@ rule warc2text:
     params:
         folder=lambda wildcards, output: os.path.dirname(os.path.dirname(output[0])),  # remove "{lang}/{pproc_file}"
         f=",".join([f.strip(".gz") for f in PPROC_FILES]),
+        paragraphs='--paragraph-identification' if PARAGRAPH_IDENTIFICATION else '',
     shell:
         """
         mkdir -p {params.folder}
-        {PROFILING} warc2text -o {params.folder} -s -f {params.f} {input}
+        {PROFILING} warc2text -o {params.folder} -s -f {params.f} {params.paragraphs} {input}
         for lang in {LANGS}; do
             if [ ! -f {params.folder}/$lang/text.gz ]; then
                 >&2 echo "WARNING: no \'$lang\' data found in {wildcards.target}: creating empty files instead"
@@ -969,7 +970,7 @@ rule custom_translate:
     threads: max(2, THREADS["translate"])
     params:
         threads=THREADS["translate"],
-        paragraphs_file=f"{TMPDIR}/custom_translate.paragraphs"
+        paragraphs_file=temp(f"{TMPDIR}/custom_translate_{{shard}}_{{src_batch}}.paragraphs")
     shell:
         """
         mkdir -p {TMPDIR}
@@ -1005,7 +1006,6 @@ rule custom_translate:
             paste <(zcat "$output") <(cat "{params.paragraphs_file}") \
                 | python3 {WORKFLOW}/utils/join_b64_docs.py \
                 | pigz -c > "{output}"
-            rm "{params.paragraphs_file}"
         fi
         """
 
@@ -1047,7 +1047,12 @@ rule tokenise_translated:
         if [ {threads} -gt 1 ]; then
             parallel_cmd="parallel --gnu --halt 2 --pipe --j {threads} -k"
         fi
+        filter_command="cat"
+        if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
+            filter_command="python3 {WORKFLOW}/utils/apply_command_b64_doc.py 'cut -f 1'"
+        fi
         zcat {input} \
+            | eval "$filter_command" \
             | {PROFILING} ${{parallel_cmd}} python3 {WORKFLOW}/bitextor_tokenize.py \
                 {params.tokeniser} {params.lemmatizer} \
                 --langcode {TRG_LANG} \
@@ -1078,7 +1083,12 @@ rule tokenise:
         if [ {threads} -gt 1 ]; then
             parallel_cmd="parallel --gnu --halt 2 --pipe --j {threads} -k"
         fi
+        filter_command="cat"
+        if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
+            filter_command="python3 {WORKFLOW}/utils/apply_command_b64_doc.py 'cut -f 1'"
+        fi
         zcat {input} \
+            | eval "$filter_command" \
             | {PROFILING} ${{parallel_cmd}} python3 {WORKFLOW}/bitextor_tokenize.py \
                 {params.tokeniser} {params.lemmatizer} \
                 --langcode {wildcards.lang} \

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -135,7 +135,7 @@ SHARDS = config["shards"]
 BATCHES = config["batches"]
 
 BOILERPLATE_CLEANING = config["boilerplateCleaning"]
-PARAGRAPH_IDENTIFICATION = False # TODO configuration
+PARAGRAPH_IDENTIFICATION = True # TODO configuration
 
 CLEANHTML = ""
 FTFY = ""
@@ -232,6 +232,7 @@ if "sentenceAlignerThreshold" in config:
 #################################################################
 # CLEANING
 FIELDS = ["url1", "url2", "seg1", "seg2", "aligner"]
+PARAGRAPH_IDENTIFICATION_FIELDS = []
 DEFERRED = ""
 MMHSUM_PATH = ""
 DEFERRED_FIELDS = []
@@ -255,15 +256,19 @@ OUTPUT_FILES = ["sent", "raw"]
 STATS_FILES = ["sent", "raw"]
 BICLEANER_TRAIN_PREFIXES = []
 
+if PARAGRAPH_IDENTIFICATION:
+    PARAGRAPH_IDENTIFICATION_FIELDS = ["para1", "para2"]
 if "deferred" in config and config["deferred"]:
     DEFERRED = "--print-sent-hash"
     MMHSUM_PATH = f"mmhsum"
     DEFERRED_FIELDS = ["checksum1", "checksum2"]
     BIFIXER_DEFERRED_COLS = "--sdeferredcol 6 --tdeferredcol 7"
+
+    if PARAGRAPH_IDENTIFICATION:
+        BIFIXER_DEFERRED_COLS = "--sdeferredcol 8 --tdeferredcol 9"
 if "bifixer" in config and config["bifixer"]:
     BIFIXER = True
     BIFIXER_FIELDS = ["bifixerhash", "bifixerscore"]
-
 if "aggressiveDedup" in config and not config["aggressiveDedup"]:
     AGGRESSIVE_DEDUP = ""
 if "bicleaner" in config and config["bicleaner"]:
@@ -302,7 +307,7 @@ if "biroamer" in config and config["biroamer"]:
     if "biroamerOmitRandomSentences" in config and config["biroamerOmitRandomSentences"]:
         BIROAMER_OMIT = "-o"
 
-BEFORE_ELRC_FIELDS = FIELDS + DEFERRED_FIELDS + BIFIXER_FIELDS + BICLEANER_FIELDS
+BEFORE_ELRC_FIELDS = FIELDS + PARAGRAPH_IDENTIFICATION_FIELDS + DEFERRED_FIELDS + BIFIXER_FIELDS + BICLEANER_FIELDS
 TMX_FIELDS = BEFORE_ELRC_FIELDS + ELRC_FIELDS
 
 FILTER_SORT_FIELDS = "-k3,4"
@@ -1234,8 +1239,14 @@ checkpoint split_segalign:
                 if [[ {input[0]} == *.gz ]]; then
                     CAT=zcat
                 fi
+                format='$2,$1,$4,$3,$5'
+                if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]] && [[ ! -z "{DEFERRED}" ]]; then
+                    format='$2,$1,$4,$3,$5,$7,$6,$9,$8'
+                elif [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]] || [[ ! -z "{DEFERRED}" ]]; then
+                    format='$2,$1,$4,$3,$5,$7,$6'
+                fi
                 $CAT {input} \
-                    | ( [ "{SRC_LANG}" = "{LANG1}" ] && cat || awk -F '\t' '{{ print $2,$1,$4,$3,$5 }}' OFS='\t' )\
+                    | ( [ "{SRC_LANG}" = "{LANG1}" ] && cat || awk -F '\t' '{{ print '$format' }}' OFS='\t' ) \
                     | python3 {WORKFLOW}/bitextor_split_segalign.py -f 3,4 -s {params.size} --gzip -o "{params.folder}/"
                 if [ -z "$(ls -A {params.folder})" ]; then
                     cat < /dev/null > {output.batches}

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -12,8 +12,9 @@ from bitextor.utils.common import (
 )
 
 valid, config = validate_args(config)
-assert valid  # workaround for not being able to exit() in snakemake
 
+if not valid:
+    raise Exception("provided configuration is not valid")
 
 #################################################################
 include: "rules/common.smk"
@@ -725,13 +726,15 @@ rule warc2preprocess:
         folder=lambda wildcards, output: os.path.dirname(os.path.dirname(output[0])),  # remove "{lang}/{pproc_file}"
         pproclangs=",".join(LANGS),
         boilerplate='--boilerpipe' if BOILERPLATE_CLEANING else '',
+        paragraphs='--paragraph-identification' if PARAGRAPH_IDENTIFICATION else '',
     shell:
         """
         mkdir -p {params.folder}
         cat {input} \
             | {PROFILING} python3 {WORKFLOW}/bitextor_warc2htmlwarc.py {CLEANHTML} {FTFY} {PDFEXTRACT} --disable-output-gzip \
             | {PROFILING} python3 {WORKFLOW}/bitextor_warc2preprocess.py --input - --langs {params.pproclangs} \
-                --compression gz --langid {LANGID} {params.boilerplate} {HTML5LIB} {PARSER} --output-dir {params.folder}
+                --compression gz --langid {LANGID} {params.boilerplate} {HTML5LIB} {PARSER} {params.paragraphs} \
+                --output-dir {params.folder}
         for lang in {LANGS}; do
             if [ ! -f {params.folder}/$lang/plain_text.gz ]; then
                 >&2 echo "WARNING: no \'$lang\' data found in {wildcards.target}: creating empty files instead"
@@ -808,7 +811,7 @@ rule prevertical2text:
             {PROFILING} prevertical2text -o {params.folder} -s -f {params.f} {params.boilerplate} {params.paragraphs} -
         for lang in {LANGS}; do
             if [ ! -f {params.folder}/$lang/text.gz ]; then
-                >&2 echo "WARNING: no \'$lang\' data found in {wildcards.target}. Creating empty files instead"
+                >&2 echo "WARNING: no \'$lang\' data found in {wildcards.target}: creating empty files instead"
                 mkdir -p {params.folder}/$lang
                 touch {params.folder}/$lang/{{{params.f}}}
                 gzip {params.folder}/$lang/{{{params.f}}}

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -968,23 +968,44 @@ rule custom_translate:
         f"{DATADIR}/shards/{SRC_LANG}/{{shard}}/{{src_batch}}/sentences_{TRG_LANG}.gz",
     threads: max(2, THREADS["translate"])
     params:
-        THREADS["translate"],
+        threads=THREADS["translate"],
+        paragraphs_file=f"{TMPDIR}/custom_translate.paragraphs"
     shell:
         """
+        mkdir -p {TMPDIR}
+        initial_nolines=$(zcat {input.source} | base64 -d | wc -l)
+        output="{output}"
+        filter_command="cat"
+        if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
+            zcat {input.source} \
+                | python3 {WORKFLOW}/utils/apply_command_b64_doc.py "cut -f 2" > "{params.paragraphs_file}"
+            para_nolines=$(cat "{params.paragraphs_file}" | base64 -d | grep -E "^p(-)?[0-9]+s(-)?[0-9]+$" | sed "/^\s*$/d" | wc -l)
+            if [[ "$initial_nolines" -ne "$para_nolines" ]]; then
+                >&2 echo "Lines count differs: source $initial_nolines, paragraph identification $para_nolines"
+                exit 1
+            fi
+            output=$(mktemp {TMPDIR}/custom_translate.tmp_output.XXXXX.gz)
+            filter_command="python3 {WORKFLOW}/utils/apply_command_b64_doc.py 'cut -f 1'"
+        fi
         parallel_cmd=""
-        if [ {params} -gt 1 ]; then
-            parallel_cmd="parallel --gnu --halt 2 --pipe --j {params} -k"
+        if [ {params.threads} -gt 1 ]; then
+            parallel_cmd="parallel --gnu --halt 2 --pipe --j {params.threads} -k"
         fi
         zcat {input.source} \
+            | eval "$filter_command" \
             | {PROFILING} b64filter cache ${{parallel_cmd}} {MT_COMMAND} \
-            | pigz -c > {output}
-        n_before=$(zcat {input.source} | base64 -d | wc -l)
-        n_after=$(zcat {output} | base64 -d | wc -l)
-        # echo "Check lines count: $n_before -> $n_after for {SRC_LANG}/{wildcards.shard}/{wildcards.src_batch}"
-        if [ $n_before -ne $n_after ]
+            | pigz -c > "$output"
+        n_after=$(zcat "$output" | base64 -d | wc -l)
+        if [ $initial_nolines -ne $n_after ]
         then
-            >&2 echo "Lines count differ: source $n_before, target $n_after"
+            >&2 echo "Lines count differs: source $initial_nolines, target $n_after"
             exit 1
+        fi
+        if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
+            paste <(zcat "$output") <(cat "{params.paragraphs_file}") \
+                | python3 {WORKFLOW}/utils/join_b64_docs.py \
+                | pigz -c > "{output}"
+            rm "{params.paragraphs_file}"
         fi
         """
 

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -135,7 +135,7 @@ SHARDS = config["shards"]
 BATCHES = config["batches"]
 
 BOILERPLATE_CLEANING = config["boilerplateCleaning"]
-PARAGRAPH_IDENTIFICATION = True # TODO configuration
+PARAGRAPH_IDENTIFICATION = False # TODO configuration
 
 CLEANHTML = ""
 FTFY = ""

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -136,7 +136,7 @@ SHARDS = config["shards"]
 BATCHES = config["batches"]
 
 BOILERPLATE_CLEANING = config["boilerplateCleaning"]
-PARAGRAPH_IDENTIFICATION = True # TODO configuration
+PARAGRAPH_IDENTIFICATION = config["paragraphIdentification"]
 
 CLEANHTML = ""
 FTFY = ""

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -979,14 +979,14 @@ rule custom_translate:
         filter_command="cat"
         if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
             zcat {input.source} \
-                | python3 {WORKFLOW}/utils/apply_command_b64_doc.py "cut -f 2" > "{params.paragraphs_file}"
+                | python3 {WORKFLOW}/utils/apply_command_b64_doc.py --empty-docs-value "" "cut -f 2" > "{params.paragraphs_file}"
             para_nolines=$(cat "{params.paragraphs_file}" | base64 -d | grep -E "^p(-)?[0-9]+s(-)?[0-9]+$" | sed "/^\s*$/d" | wc -l)
             if [[ "$initial_nolines" -ne "$para_nolines" ]]; then
                 >&2 echo "Lines count differs: source $initial_nolines, paragraph identification $para_nolines"
                 exit 1
             fi
             output=$(mktemp {TMPDIR}/custom_translate.tmp_output.XXXXX.gz)
-            filter_command="python3 {WORKFLOW}/utils/apply_command_b64_doc.py 'cut -f 1'"
+            filter_command="python3 {WORKFLOW}/utils/apply_command_b64_doc.py --empty-docs-value '' 'cut -f 1'"
         fi
         parallel_cmd=""
         if [ {params.threads} -gt 1 ]; then

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -980,7 +980,7 @@ rule custom_translate:
         if [[ "{PARAGRAPH_IDENTIFICATION}" == "True" ]]; then
             zcat {input.source} \
                 | python3 {WORKFLOW}/utils/apply_command_b64_doc.py --empty-docs-value "" "cut -f 2" > "{params.paragraphs_file}"
-            para_nolines=$(cat "{params.paragraphs_file}" | base64 -d | grep -E "^p(-)?[0-9]+s(-)?[0-9]+$" | sed "/^\s*$/d" | wc -l)
+            para_nolines=$(cat "{params.paragraphs_file}" | base64 -d | grep -E "^p[0-9]+s[0-9]+$|^p-1s-1$" | sed "/^\s*$/d" | wc -l)
             if [[ "$initial_nolines" -ne "$para_nolines" ]]; then
                 >&2 echo "Lines count differs: source $initial_nolines, paragraph identification $para_nolines"
                 exit 1

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -57,7 +57,6 @@ USERAGENT = "Mozilla/5.0 (compatible; Bitextor/8 +https://github.com/bitextor/bi
 CRAWLSIZELIMIT = ""
 CRAWLTIMELIMIT = ""
 CRAWLWAIT = ""
-CRAWLPAGELIMIT = ""
 CRAWLFILETYPES = []
 CRAWLJOBS = "2"
 CRAWLTIMEOUT = "10"
@@ -75,6 +74,7 @@ if "crawler" in config:
     CRAWLTARGET = config["crawler"]
 
     if CRAWLTARGET == "linguacrawl":
+        # TODO should we change this default value, as we have done with wget, as well?
         CRAWLFILETYPES = ["text/html", "application/pdf"]
 if "crawlTLD" in config and config["crawlTLD"]:
     TLD_CRAWL = config["crawlTLD"]
@@ -135,7 +135,7 @@ SHARDS = config["shards"]
 BATCHES = config["batches"]
 
 BOILERPLATE_CLEANING = config["boilerplateCleaning"]
-PARAGRAPH_IDENTIFICATION = False # TODO configuration
+PARAGRAPH_IDENTIFICATION = True # TODO configuration
 
 CLEANHTML = ""
 FTFY = ""
@@ -892,6 +892,7 @@ rule split:
     params:
         splitter=lambda wildcards: apply_format(get_lang_or_default(SENTTOKS, wildcards.lang), '--sentence-splitter "{}"'),
         customnbp=lambda wildcards: apply_format(get_customnbp(CUSTOMNBPS, wildcards.lang), '--customnbp "{}"'),
+        paragraphs='--process-paragraphs' if PARAGRAPH_IDENTIFICATION else '',
     output:
         f"{DATADIR}/shards/{{lang}}/{{shard}}/{{batch}}/sentences.gz",
     threads: THREADS["split"]
@@ -905,7 +906,7 @@ rule split:
             | {PROFILING} ${{parallel_cmd}} python3 {WORKFLOW}/bitextor_split.py \
                 {params.splitter} {params.customnbp} \
                 --langcode "{wildcards.lang}" \
-                {PRUNE_THRESHOLD} {PRUNE_TYPE} \
+                {PRUNE_THRESHOLD} {PRUNE_TYPE} {params.paragraphs} \
             | pigz -c > {output}
         """
 
@@ -1154,6 +1155,7 @@ rule bleualign:
     params:
         folder=lambda wildcards, output: os.path.dirname(output[0]),
         workers=THREADS["segalign"],
+        paragraphs='--paragraph-identification' if PARAGRAPH_IDENTIFICATION else '',
     # in segalign rule output columns are reordered (or not) in accordance with translationDirection
     output:
         f"{TRANSIENT}/{SRC_LANG}_{TRG_LANG}/{{shard}}/{SRC_LANG}{{src_batch}}_{TRG_LANG}{{trg_batch}}.06_02.segalign.gz",
@@ -1170,7 +1172,8 @@ rule bleualign:
                 -l {input.url1} -r {input.url2} \
                 -l {input.plain1} -r {input.plain2} \
                 -l {input.translated1} \
-            | {PROFILING} ${{parallel_cmd}} bleualign_cpp {DEFERRED} --bleu-threshold {SEGALIGN_THRESHOLD} \
+            | {PROFILING} ${{parallel_cmd}} bleualign_cpp {DEFERRED} {params.paragraphs} \
+                --bleu-threshold {SEGALIGN_THRESHOLD} \
             | pigz -c > {output}
         """
 

--- a/bitextor/bitextor_buildTMX.py
+++ b/bitextor/bitextor_buildTMX.py
@@ -39,7 +39,7 @@ from xml.sax.saxutils import escape
 from bitextor.utils.common import open_xz_or_gzip_or_plain, dummy_open
 
 
-def printseg(lang, seg_columns, urls, seg, fields_dict, mint, checksum=None, no_delete_seg=False):
+def printseg(lang, seg_columns, urls, seg, fields_dict, mint, checksum=None, no_delete_seg=False, paragraph_id=None):
     info_tag = []
     print("    <tuv xml:lang=\"" + lang + "\">")
     if "url1" in seg_columns:
@@ -47,6 +47,8 @@ def printseg(lang, seg_columns, urls, seg, fields_dict, mint, checksum=None, no_
             print("     <prop type=\"source-document\">" + escape(url) + "</prop>")
     if checksum:
         print("     <prop type=\"checksum-seg\">" + checksum + "</prop>")
+    if paragraph_id:
+        print("     <prop type=\"paragraph-id\">" + paragraph_id + "</prop>")
 
     if no_delete_seg or checksum is None:
         print("     <seg>" + escape(seg) + "</seg>")
@@ -76,10 +78,10 @@ def printtu(tu_idcounter, lang1, lang2, tu_columns, tu_urls1, tu_urls2, fields_d
     if len(info_tag) > 0:
         print("    <prop type=\"info\">" + "|".join(info_tag) + "</prop>")
 
-    if 'checksum1' not in fields_dict:
-        fields_dict['checksum1'] = None
-    if 'checksum2' not in fields_dict:
-        fields_dict['checksum2'] = None
+    # Initialize fields if value was not provided
+    for field in ('checksum1', 'checksum2', 'para1', 'para2'):
+        if field not in fields_dict:
+            fields_dict[field] = None
 
     printseg(
         lang1,
@@ -89,7 +91,8 @@ def printtu(tu_idcounter, lang1, lang2, tu_columns, tu_urls1, tu_urls2, fields_d
         fields_dict,
         mint,
         fields_dict['checksum1'],
-        no_delete_seg)
+        no_delete_seg,
+        fields_dict['para1'])
     printseg(
         lang2,
         tu_columns,
@@ -98,7 +101,8 @@ def printtu(tu_idcounter, lang1, lang2, tu_columns, tu_urls1, tu_urls2, fields_d
         fields_dict,
         mint,
         fields_dict['checksum2'],
-        no_delete_seg)
+        no_delete_seg,
+        fields_dict['para2'])
 
     print("   </tu>")
 
@@ -143,7 +147,7 @@ with open_xz_or_gzip_or_plain(options.clean_alignments, 'rt') if options.clean_a
     print("   srclang=\"" + options.lang1 + "\"")
     print("   o-tmf=\"PlainText\"")
     print("   creationtool=\"bitextor\"")
-    print("   creationtoolversion=\"4.0\"")
+    print("   creationtoolversion=\"8.1\"")
     print("   datatype=\"PlainText\"")
     print("   segtype=\"sentence\"")
     print("   creationdate=\"" + time.strftime("%Y%m%dT%H%M%S") + "\"")

--- a/bitextor/bitextor_split.py
+++ b/bitextor/bitextor_split.py
@@ -20,6 +20,7 @@ import os
 import argparse
 import base64
 import string
+import logging
 
 from sentence_splitter import SentenceSplitter, SentenceSplitterException
 
@@ -40,8 +41,8 @@ def filter_trash(sentence):
     return n < len(sentence) // 2
 
 
-def split_external(text, external_splitter, prune_type="words", prune_threshold=0):
-    output, error_output, returncode = external_splitter.process(content)
+def split_external(text, external_splitter, prune_type="words", prune_threshold=0, filter_bad_sentences=True):
+    output, error_output, returncode = external_splitter.process(text)
     if returncode != 0:
         print(f"External sentence splitter existed with non-zero code: {returncode}", file=sys.stderr)
         print(error_output.strip(), file=sys.stderr)
@@ -54,14 +55,15 @@ def split_external(text, external_splitter, prune_type="words", prune_threshold=
     elif prune_threshold and prune_type == "chars":
         segments = [s for s in segments if not len(s) > prune_threshold]
 
-    segments = [s for s in segments if filter_trash(s)]
+    if filter_bad_sentences:
+        segments = [s for s in segments if filter_trash(s)]
 
     segmented_text = "\n".join(segments) + "\n"
     return segmented_text
 
 
-def split_moses(text, moses_splitter, prune_type="words", prune_threshold=0):
-    segments = moses_splitter.split(content)
+def split_moses(text, moses_splitter, prune_type="words", prune_threshold=0, filter_bad_sentences=True):
+    segments = moses_splitter.split(text)
 
     # prune long sentences
     if prune_threshold and prune_type == "words":
@@ -69,26 +71,34 @@ def split_moses(text, moses_splitter, prune_type="words", prune_threshold=0):
     elif prune_threshold and prune_type == "chars":
         segments = [s for s in segments if not len(s) > prune_threshold]
 
-    segments = [s for s in segments if filter_trash(s)]
+    if filter_bad_sentences:
+        segments = [s for s in segments if filter_trash(s)]
 
     segmented_text = "\n".join(segments) + "\n"
     return segmented_text
 
 
 oparser = argparse.ArgumentParser(description="Tool that does sentence splitting on plain text")
-oparser.add_argument('--text', dest='text', help='Plain text file', default="-")
-oparser.add_argument('--sentence-splitter', dest='splitter', default=None, help="Sentence splitter command line. "
-                     "If not provided, Moses split_sentences Python port will be used.")
-oparser.add_argument('--langcode', dest='langcode', default="en",
+oparser.add_argument('--text', default="-",
+                     help="Plain text file")
+oparser.add_argument('--sentence-splitter', dest='splitter', default=None,
+                     help="Sentence splitter command line. If not provided, Moses split_sentences Python port "
+                          "will be used")
+oparser.add_argument('--langcode', default="en",
                      help="Language code for default sentence splitter and tokenizer")
-oparser.add_argument('--customnbp', dest='customnbp',
+oparser.add_argument('--customnbp',
                      help="Path for custom non breaking prefixes used by Moses Sentence Splitter Python port")
 oparser.add_argument('--sentences-output', default="plain_sentences.xz", dest='sent_output',
                      help="Path of the output file that will contain sentence splitted text")
 oparser.add_argument("--prune", dest="prune_threshold", type=int, default=0,
-                     help="Prune sentences longer than n (words/characters)", required=False)
-oparser.add_argument("--prune-type", dest="prune_type", choices={"words", "chars"}, default="words",
-                     help="Prune sentences either by words or characters", required=False)
+                     help="Prune sentences longer than n (words/characters)")
+oparser.add_argument("--prune-type", choices={"words", "chars"}, default="words",
+                     help="Prune sentences either by words or characters")
+oparser.add_argument('--dont-filter', action='store_true',
+                     help="By default, sentences which are detected to be very noisy or have very bad quality are discarded")
+oparser.add_argument('--process-paragraphs', action='store_true',
+                     help="Once the sentence had been base64-decoded, the second column contains the paragraph "
+                          "identification which will be processed")
 
 options = oparser.parse_args()
 
@@ -114,6 +124,38 @@ else:
 
 with open_xz_or_gzip_or_plain(options.text) if options.text != "-" else sys.stdin as reader:
     for doc in reader:
-        content = base64.b64decode(doc.strip()).decode("utf-8").replace("\t", " ")
-        sentences = splitter_func(content, splitter, options.prune_type, options.prune_threshold)
-        print(base64.b64encode(sentences.encode("utf-8")).decode("utf-8"))
+        sentences = ""
+        content = ""
+
+        try:
+            content = base64.b64decode(doc.strip()).decode("utf-8").strip()
+        except UnicodeDecodeError:
+            pass
+
+        if options.process_paragraphs:
+            content = content.split("\n")
+
+            # Split each sentence of the paragraph and identify each of them with the corresponding paragraph
+            for sentence in content:
+                paragraph = sentence.split("\t")
+
+                try:
+                    paragraph_text = paragraph[0]
+                    paragraph_id = paragraph[1]
+
+                    sentences_wo_paragraphs = splitter_func(paragraph_text, splitter, options.prune_type,
+                                                            options.prune_threshold, not options.dont_filter).split("\n")
+
+                    # Add the paragraph data to the splitted sentences
+                    for idx in range(len(sentences_wo_paragraphs)):
+                        if sentences_wo_paragraphs[idx].strip() != "":
+                            sentences += f"{sentences_wo_paragraphs[idx]}\tp{paragraph_id}s{idx}\n"
+                except IndexError as e:
+                    logging.error("could not get the paragraph identification data")
+                    raise e
+        else:
+            content = content.replace("\t", " ")
+            sentences = splitter_func(content, splitter, options.prune_type, options.prune_threshold, not options.dont_filter)
+
+        if sentences.strip() != "":
+            print(base64.b64encode(sentences.encode("utf-8")).decode("utf-8"))

--- a/bitextor/bitextor_split.py
+++ b/bitextor/bitextor_split.py
@@ -42,11 +42,7 @@ def filter_trash(sentence):
 
 
 def split_external(text, external_splitter, prune_type="words", prune_threshold=0, filter_bad_sentences=True):
-    output, error_output, returncode = external_splitter.process(text)
-    if returncode != 0:
-        print(f"External sentence splitter existed with non-zero code: {returncode}", file=sys.stderr)
-        print(error_output.strip(), file=sys.stderr)
-        sys.exit(1)
+    output = external_splitter.process(text)
 
     segments = output.strip().split("\n")
     # prune long sentences
@@ -140,8 +136,8 @@ with open_xz_or_gzip_or_plain(options.text) if options.text != "-" else sys.stdi
                 paragraph = sentence.split("\t")
 
                 if len(paragraph) == 1:
-                    sentences += f"{paragraph[0]}\ts-1p-1\n"
-                    logging.warning(f"could not get the paragraph identification data for the doc #{doc_idx}, sentence #{sent_idx}: using 's-1p-1'")
+                    sentences += f"{paragraph[0]}\tp-1s-1\n"
+                    logging.warning(f"could not get the paragraph identification data for the doc #{doc_idx}, sentence #{sent_idx}: using 'p-1s-1'")
                     continue
 
                 paragraph_text = ' '.join(paragraph[:-1]).strip() # Replace '\t' with ' '

--- a/bitextor/bitextor_split.py
+++ b/bitextor/bitextor_split.py
@@ -137,12 +137,13 @@ with open_xz_or_gzip_or_plain(options.text) if options.text != "-" else sys.stdi
 
             # Split each sentence of the paragraph and identify each of them with the corresponding paragraph
             for sent_idx, sentence in enumerate(content):
-                if sentence == '':
-                    sentences += f"\ts-1p-1"
+                paragraph = sentence.split("\t")
+
+                if len(paragraph) == 1:
+                    sentences += f"{paragraph[0]}\ts-1p-1"
                     logging.warning(f"could not get the paragraph identification data for the doc #{doc_idx}, sentence #{sent_idx}: using 's-1p-1'")
                     continue
 
-                paragraph = sentence.split("\t")
                 paragraph_text = paragraph[0]
                 paragraph_id = paragraph[1]
                 sentences_wo_paragraphs = splitter_func(paragraph_text, splitter, options.prune_type,

--- a/bitextor/bitextor_warc2preprocess.py
+++ b/bitextor/bitextor_warc2preprocess.py
@@ -237,6 +237,8 @@ oparser.add_argument('--langs', dest="langs", default="",
 oparser.add_argument('--langid', dest="langid", default="cld2", help="Model used for language detection: cld2 or cld3")
 oparser.add_argument('--compression', dest='compression', default='gz', choices={'xz', 'gz'},
                      help='Compression type for the output files')
+oparser.add_argument('--paragraph-identification', action='store_true',
+                     help='Add paragraph index in each b64encoded document sentence as tab separated column')
 options = oparser.parse_args()
 
 logging.basicConfig(
@@ -467,6 +469,12 @@ for record in f:
         seen_plain_text.add(plaintext_hash)
         # Guessing MIME of the file (checked on original content)
         logging.info(url + ": Getting mime")
+
+        if options.paragraph_identification:
+            # Add paragraph index
+            plaintext = [f"{element}\t{idx}" for idx, element in enumerate(plaintext.strip().split("\n"))]
+            plaintext = '\n'.join(plaintext)
+
         mime = magic.from_buffer(text, mime=True)
 
         if not options.xzlang:
@@ -483,6 +491,7 @@ for record in f:
 
             b64text = base64.b64encode(html.unescape(plaintext).encode())
             files_dict[lang]["plainTextFile"].write(b64text + b"\n")
+
         # append to language specific file
         else:
             langfile = lzma.open(options.outDir + "/" + lang, mode="a", format=lzma.FORMAT_XZ)

--- a/bitextor/bitextor_wget.py
+++ b/bitextor/bitextor_wget.py
@@ -19,6 +19,8 @@ import argparse
 import subprocess
 import sys
 import requests
+import time
+
 from warcio.archiveiterator import ArchiveIterator
 from warcio.warcwriter import WARCWriter
 from warcio.statusandheaders import StatusAndHeaders
@@ -65,7 +67,8 @@ def run(url, out_path, time_limit, agent, filetypes, warcfilename, wait):
 
     cmd += f"wget --mirror {waitoption} {filetypesoption} -q -o /dev/null {url} -P {out_path} {agentoption} {warcoption}"
 
-    # print("cmd", cmd)
+    start_time = time.time()
+
     try:
         system_check(cmd)
     except subprocess.CalledProcessError as grepexc:
@@ -75,6 +78,8 @@ def run(url, out_path, time_limit, agent, filetypes, warcfilename, wait):
             suffix = " (timeout)"
 
         sys.stderr.write(f"WARNING: some files could not be downloaded with wget{suffix}\n")
+
+    print(f"The crawling took {time.time() - start_time:.0f} seconds")
 
     with open(warcfilebasename + ".warc", 'rb') as f_in:
         with open(warcfilebasename + ".warc.gz", 'wb') as f_out:

--- a/bitextor/rules/common.smk
+++ b/bitextor/rules/common.smk
@@ -269,7 +269,7 @@ def get_customnbp(nbp_dict, language):
 Helper function to format parameters to pass to scripts
 """
 def apply_format(string, replace_format, replace_token="{}", replace_only_if_true=True):
-    if replace_only_if_true and string or not replace_only_if_true:
+    if (replace_only_if_true and string) or not replace_only_if_true:
         return replace_format.replace(replace_token, string)
 
     return string

--- a/bitextor/utils/apply_command_b64_doc.py
+++ b/bitextor/utils/apply_command_b64_doc.py
@@ -1,0 +1,102 @@
+#  This file is part of Bitextor.
+#
+#  Bitextor is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Bitextor is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Bitextor.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import shlex
+import base64
+import logging
+import argparse
+import contextlib
+import subprocess
+
+def execute(command, input_file='-', use_shell=False, remove_empty_docs=False, empty_docs_value='Cg==',
+            is_plaintext=False):
+    command = command if use_shell else shlex.split(command)
+    non_empty_docs = 0
+    empty_docs = 0
+    processed_sentences = 0
+    total_sentences = 0
+    cm = contextlib.nullcontext(sys.stdin)
+
+    if input_file != '-':
+        cm = open(input_file)
+
+    with cm as doc_fd:
+        for idx, doc in enumerate(doc_fd):
+            try:
+                doc = doc.strip()
+
+                if is_plaintext:
+                    sentences = doc.encode('utf-8')
+                else:
+                    sentences = base64.b64decode(doc)
+
+                    total_sentences += sentences.decode('utf-8').strip().count('\n') + 1
+
+                # Execute command for the sentences of the current document, BASE64-decoded
+                command_result = subprocess.Popen(command, shell=use_shell, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                sentences = command_result.communicate(sentences)[0]
+
+                processed_sentences += sentences.decode('utf-8').strip().count('\n') + 1
+
+                sentences = base64.b64encode(sentences).decode("utf-8")
+
+                if sentences.strip() != '':
+                    print(sentences)
+                    non_empty_docs += 1
+                elif not remove_empty_docs:
+                    # Print, at least, a minimum document content -> #input documents = #output documents
+                    print(empty_docs_value)
+                    empty_docs += 1
+                else:
+                    empty_docs += 1
+
+            except Exception as e:
+                raise Exception(f"doc #{idx + 1} could not be processed") from e
+
+    logging.debug("%d documents were empty, and %d were not", empty_docs, non_empty_docs)
+    logging.debug("%d sentences were returned (initial sentences: %d)", processed_sentences - (0 if remove_empty_docs else empty_docs), total_sentences)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="It processes BASE64 documents with a provided command and returns the BASE64-encoded result",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('command',
+                        help="Command which will be executed")
+    parser.add_argument('--input', default='-',
+                        help="Input file. If '-' is provided, stdin will be used")
+    parser.add_argument('--input-is-not-base64', action='store_true',
+                        help="Input is expected to be BASE64-encoded text, but with this option plaintext will be expected instead")
+    parser.add_argument('--use-shell', action='store_true',
+                        help="When using shell=True with subprocess, we lose control but the evaluation of the provided command is literal, so"
+                             "even pipes can be used")
+    parser.add_argument('--remove-empty-docs', action='store_true',
+                        help="By default, empty documents, result of the provided command, are kept")
+    parser.add_argument('--empty-docs-value', default='Cg==',
+                        help="Default value to use when an empty document is produced, result of the provided command. It should be a BASE64 value")
+    parser.add_argument('--logging-level', type=int, default=logging.INFO,
+                        help="Logging level")
+
+    args = parser.parse_args()
+
+    return args
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    logging.basicConfig(level=args.logging_level)
+
+    execute(args.command, input_file=args.input, use_shell=args.use_shell, remove_empty_docs=args.remove_empty_docs,
+            empty_docs_value=args.empty_docs_value, is_plaintext=args.input_is_not_base64)

--- a/bitextor/utils/args.py
+++ b/bitextor/utils/args.py
@@ -229,6 +229,11 @@ def validate_args(config):
             schema['boilerplateCleaning']['check_with'] = \
                 genericerror("mandatory: preprocessor warc2preprocess or provide prevertical files")
 
+    if config['preprocessor'] == 'warc2preprocess':
+        if provided_in_config['preverticals'] or provided_in_config['preverticalsFile']:
+            schema['preverticals']['dependencies'] = {'preprocessor': ['warc2text']}
+            schema['preverticalsFile']['dependencies'] = {'preprocessor': ['warc2text']}
+
     if config['documentAligner'] == 'externalMT':
         schema['alignerCmd']['required'] = True
         if monolingual_workflow and 'alignedCmd' not in config:

--- a/bitextor/utils/args.py
+++ b/bitextor/utils/args.py
@@ -123,6 +123,7 @@ def validate_args(config):
         'langs': {'type': 'list'},
         'shards': {'type': 'integer', 'min': 0, 'default': 8},
         'batches': {'type': 'integer', 'min': 1, 'default': 1024},
+        'paragraphIdentification': {'type': 'boolean', 'default': False},
         # specific to warc2text:
         'writeHTML': {'type': 'boolean', 'dependencies': {'preprocessor': ['warc2text']}},
         # specific to warc2preprocess:

--- a/bitextor/utils/common.py
+++ b/bitextor/utils/common.py
@@ -1,7 +1,3 @@
-try:
-    import lzma
-except ImportError:
-    from backports import lzma
 #  This file is part of Bitextor.
 #
 #  Bitextor is free software: you can redistribute it and/or modify
@@ -16,6 +12,11 @@ except ImportError:
 #
 #  You should have received a copy of the GNU General Public License
 #  along with Bitextor.  If not, see <https://www.gnu.org/licenses/>.
+
+try:
+    import lzma
+except ImportError:
+    from backports import lzma
 
 import gzip
 from contextlib import contextmanager

--- a/bitextor/utils/join_b64_docs.py
+++ b/bitextor/utils/join_b64_docs.py
@@ -1,0 +1,103 @@
+#  This file is part of Bitextor.
+#
+#  Bitextor is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Bitextor is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Bitextor.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import shlex
+import base64
+import logging
+import argparse
+import contextlib
+import subprocess
+
+def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
+    cm = contextlib.nullcontext(sys.stdin)
+    columns = set()
+
+    if input_file != '-':
+        cm = open(input_file)
+
+    with cm as doc_fd:
+        for idx, doc in enumerate(doc_fd):
+            try:
+                doc = doc.strip().split(separator)
+                segments = []
+                text = []
+
+                # Get all the segments from the current document
+                for segment in doc:
+                    if not is_plaintext:
+                        segment = base64.b64decode(segment).decode('utf-8')
+
+                    segments.append(segment)
+
+                columns.add(len(segments))
+                nosentences = set()
+                sentences_from_segments = []
+
+                # Get all the sentences from all the segments
+                for segment in segments:
+                    sentences = segment.strip().split('\n')
+
+                    sentences_from_segments.append(sentences)
+                    nosentences.add(len(sentences))
+
+                if len(nosentences) not in (0, 1):
+                    raise Exception(f"document #{idx + 1}: same number of sentences were expected, but got different")
+
+                # Join all the sentences from the segments for the current document
+                if len(nosentences) == 1:
+                    nosentences = nosentences.pop()
+
+                    for i in range(nosentences):
+                        current_sentence = join_str.join([sentences_from_segments[j][i] for j in range(len(sentences_from_segments))])
+
+                        text.append(current_sentence)
+
+
+                doc = '\n'.join(text).encode('utf-8')
+                doc = base64.b64encode(doc).decode('utf-8')
+
+                print(doc)
+            except Exception as e:
+                raise Exception(f"document #{idx + 1} could not be processed") from e
+
+    if len(columns) not in (0, 1):
+        logging.warning("different number of segments (columns) were processed: %s", columns)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="It joins the sentences of the content from BASE64 documents and returns a new BASE64-encoded document",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('--input', default='-',
+                        help="Input file. If '-' is provided, stdin will be used")
+    parser.add_argument('--input-is-not-base64', action='store_true',
+                        help="Input is expected to be BASE64-encoded text, but with this option plaintext will be expected instead")
+    parser.add_argument('--separator', default='\t',
+                        help="Separator which will be used to split the initial input")
+    parser.add_argument('--join-str', default='\t',
+                        help="String which will be used to join the BASE64-decoded sentences before encode the document again")
+    parser.add_argument('--logging-level', type=int, default=logging.INFO,
+                        help="Logging level")
+
+    args = parser.parse_args()
+
+    return args
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    logging.basicConfig(level=args.logging_level)
+
+    join(input_file=args.input, separator=args.separator, join_str=args.join_str, is_plaintext=args.input_is_not_base64)

--- a/bitextor/utils/join_b64_docs.py
+++ b/bitextor/utils/join_b64_docs.py
@@ -21,7 +21,8 @@ import argparse
 import contextlib
 import subprocess
 
-def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
+def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False, encode_errors='strict',
+         decode_errors='strict'):
     if separator == '\n':
         raise Exception(f"the provided separator is not valid: '{repr(separator)}'")
 
@@ -41,7 +42,7 @@ def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
                 # Get all the segments from the current document
                 for segment in doc:
                     if not is_plaintext:
-                        segment = base64.b64decode(segment).decode('utf-8')
+                        segment = base64.b64decode(segment).decode('utf-8', errors=decode_errors)
 
                     segments.append(segment)
 
@@ -71,9 +72,8 @@ def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
 
                         text.append(current_sentence)
 
-
-                doc = '\n'.join(text).encode('utf-8')
-                doc = base64.b64encode(doc).decode('utf-8')
+                doc = '\n'.join(text).encode('utf-8', errors=encode_errors)
+                doc = base64.b64encode(doc).decode('utf-8', errors=decode_errors)
 
                 print(doc)
             except Exception as e:
@@ -94,6 +94,10 @@ def parse_args():
                         help="Separator which will be used to split the initial input")
     parser.add_argument('--join-str', default='\t',
                         help="String which will be used to join the BASE64-decoded sentences before encode the document again")
+    parser.add_argument('--encode-errors', default='strict',
+                        help="How encoding errors should be handled. Check 'errors' parameter from 'encode' method")
+    parser.add_argument('--decode-errors', default='strict',
+                        help="How decoding errors should be handled. Check 'errors' parameter from 'decode' method")
     parser.add_argument('--logging-level', type=int, default=logging.INFO,
                         help="Logging level")
 
@@ -106,4 +110,5 @@ if __name__ == '__main__':
 
     logging.basicConfig(level=args.logging_level)
 
-    join(input_file=args.input, separator=args.separator, join_str=args.join_str, is_plaintext=args.input_is_not_base64)
+    join(input_file=args.input, separator=args.separator, join_str=args.join_str, is_plaintext=args.input_is_not_base64,
+         encode_errors=args.encode_errors, decode_errors=args.decode_errors)

--- a/bitextor/utils/join_b64_docs.py
+++ b/bitextor/utils/join_b64_docs.py
@@ -22,6 +22,9 @@ import contextlib
 import subprocess
 
 def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
+    if separator == '\n':
+        raise Exception(f"the provided separator is not valid: '{repr(separator)}'")
+
     cm = contextlib.nullcontext(sys.stdin)
     columns = set()
 
@@ -31,7 +34,7 @@ def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
     with cm as doc_fd:
         for idx, doc in enumerate(doc_fd):
             try:
-                doc = doc.strip().split(separator)
+                doc = doc.strip('\n').split(separator)
                 segments = []
                 text = []
 
@@ -48,7 +51,10 @@ def join(input_file='-', separator='\t', join_str='\t', is_plaintext=False):
 
                 # Get all the sentences from all the segments
                 for segment in segments:
-                    sentences = segment.strip().split('\n')
+                    if len(segment) > 0 and segment[-1] == '\n':
+                        segment = segment[:-1]
+
+                    sentences = segment.split('\n')
 
                     sentences_from_segments.append(sentences)
                     nosentences.add(len(sentences))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -190,6 +190,9 @@ langID: cld2
 ## remove boilerplate, only warc2preprocess in WARC processing and prevertical2text in prevertical files
 boilerplateCleaning: true
 
+## identify paragraphs
+paragraphIdentification: true
+
 # sharding
 shards: 8 # 2^8 shards
 batches: 1024 # batches of up to 1024MB
@@ -215,6 +218,10 @@ Options specific to `warc2preprocess`:
 Boilerplate:
 
 * `boilerplateCleaning`: if `preprocessor: warc2preprocess`, enables [boilerpipe](https://boilerpipe-web.appspot.com/) to remove boilerplates from HTML documents. If you have provided `preverticals` files, it will discard those entries detected as boilerplate by `prevertical2text` automatically. `warc2text` does not support this option. It is disabled by default
+
+Paragraph identification:
+
+* `paragraphIdentification`: if this option is enabled, the selected `preprocessor` will generate information which will identify the paragraphs. This information will be used to link every sentence to the position which it took in the original paragraph.
 
 Sharding options:
 

--- a/docs/OUTPUT.md
+++ b/docs/OUTPUT.md
@@ -8,28 +8,31 @@ The files that will be always generated (regardless of configuration) are `{lang
 
 * `{lang1}-{lang2}.raw.gz`: parallel corpus that contains every aligned sentences, has **no deduplication** and the sentences are **not filtered**.
 
-    This file contains columns added by different optional modules: **deferred**, **Bifixer** and **Bicleaner**. In case some of these are not enabled, the corresponding columns will be omitted. The possible fields that may appear in this file are (in this order):
+    This file contains columns added by different optional modules/features: **paragraph identification**, **deferred**, **Bifixer** and **Bicleaner**. In case some of these are not enabled, the corresponding columns will be omitted. The possible fields that may appear in this file are (in this order):
 
     1. `url1 url2 sent1 sent2 aligner_score` - default columns
         * `url1` and `url2` are source documents of the sentences
         * `sent1` and `sent2` form a sentence pair in `lang1` and `lang2`
         * `aligner_score` is the score given by the sentence aligner (bleualign or hunalign)
-    2. `checksum1 checksum2` - deferred sentence checksums
+    2. `para1 para2` - paragraph identification data
+        * initial position of the sentence in the paragraph, and initial position of the paragraph in the document
+    3. `checksum1 checksum2` - deferred sentence checksums
         * may be used to reconstruct the original corpus using [Deferred crawling reconstructor](https://github.com/bitextor/deferred-crawling)
-    3. `bifixer_hash bifixer_score` - Bifixer output
+    4. `bifixer_hash bifixer_score` - Bifixer output
         * `bifixer_hash` tags duplicate or near-duplicate sentences
         * `bifixer_score` rates quality of duplicate or near-duplicate sentences
-    4. `bicleaner_score` - Bicleaner classifer output
+    5. `bicleaner_score` - Bicleaner classifer output
 
     This file comes accompanied by the corresponding statistics file `{lang1}-{lang2}.stats.raw`, which provides information the size of the corpus in MB and in number of  tokens.
 
 * `{lang1}-{lang2}.sent.gz`: parallel corpus after running all of the steps described above, plus **filtering** according to the specified Bicleaner threshold, adding **ELRC** metrics, and **sorted** to have the duplicate or (near-duplicate) sentences together. This file will have all of the columns from `raw` files, plus 3 new ones corresponding to ELRC metrics.
 
     1. `url1 url2 sent1 sent2 aligner_score` - default columns
-    2. `checksum1 checksum2` - deferred sentence checksums
-    3. `bifixer_hash bifixer_score` - Bifixer output
-    4. `bicleaner_score` - Bicleaner classifier output
-    5. `length_ratio num_tokens_src num_tokens_trg` - ELRC fields
+    2. `para1 para2` - paragraph identification data
+    3. `checksum1 checksum2` - deferred sentence checksums
+    4. `bifixer_hash bifixer_score` - Bifixer output
+    5. `bicleaner_score` - Bicleaner classifier output
+    6. `length_ratio num_tokens_src num_tokens_trg` - ELRC fields
         * `num_tokens_src` is the number of tokens in source sentence
         * `num_tokens_trg` is the number of tokens in target sentence
         * `length_ratio` is the ratio between the two (source divided by target)


### PR DESCRIPTION
New feature implemented: `paragraphIdentification`. This feature adds a new column to the necessary files of the Bitextor pipeline. The new column identifies each gathered segment from the HTML/prevertical files with a paragraph identifier. The format is: `p<paragraph identifier>/<no. paragraphs>s<segment identifier>/<no. segments>`. The identifiers start at 1, and the gap filler feature has been taken into account and multiple paragraph identifiers may be joined.

If resplit is enabled in Bifixer, the paragraph identifiers should be identified as well as the deferred hashes. This feature is implemented in PR https://github.com/bitextor/bifixer/pull/12, but not integrated yet. Once the PR is accepted, it will be integrated (either in the master branch if this PR have been accepted then or in this PR if not). The format, when resplit, is `<previous format>#<resplit sentence identifier>`.

Documentation has been updated according to the new feature.

Other changes:
- Script sentence_split.py has been slightly modified and does not have the same behaviour than before (it strips all the sentences, what leads to a better splitting sometimes and leads to slightly different, but better, results).
- "creationtoolversion" TMX option has been updated to the correct version.
- Bug in `ExternalTextProcessor` fixed (discussed in issue #224).