### PR TITLE
CI and tests updates and fixes

### DIFF
--- a/.github/workflows/build-and-test-bitextor-only.yaml
+++ b/.github/workflows/build-and-test-bitextor-only.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v3
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/build-and-test-bitextor-only.yaml
+++ b/.github/workflows/build-and-test-bitextor-only.yaml
@@ -57,7 +57,7 @@ jobs:
       -  name: Compiling bitextor and submodules
          run: |
             mkdir build_cmake && cd build_cmake
-            cmake -DSKIP_MGIZA=ON -DCMAKE_INSTALL_PREFIX=/usr ..
+            cmake -DCMAKE_INSTALL_PREFIX=/usr ..
             make -j
             sudo make install
       -  name: Run tests

--- a/.github/workflows/build-and-test-bitextor-only.yaml
+++ b/.github/workflows/build-and-test-bitextor-only.yaml
@@ -17,7 +17,7 @@ jobs:
    build_and_testing:
       name: Build and testing Bitextor only
       runs-on: ubuntu-20.04
-      timeout-minutes: 1440
+      timeout-minutes: 360
       steps:
       -  name: Install required linux packages
          run: |
@@ -91,7 +91,7 @@ jobs:
                   echo ""
                done < "${WORK}/data/fails.log"
             else
-               >&2 echo "ERROR: could not find the file which contain the fails, and should exist"
+               >&2 echo "ERROR: could not find the file with the detailed fails"
                exit 1
             fi
       -  name: Upload sent.gz files (artifacts)

--- a/.github/workflows/build-and-test-bitextor-only.yaml
+++ b/.github/workflows/build-and-test-bitextor-only.yaml
@@ -5,12 +5,10 @@ on:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
    pull_request:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
 
 env:
    WORK: ${{ github.workspace }}

--- a/.github/workflows/build-and-test-bitextor-only.yaml
+++ b/.github/workflows/build-and-test-bitextor-only.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v3
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -65,7 +65,7 @@ jobs:
       -  name: Compiling bitextor and submodules
          run: |
             mkdir build_cmake && cd build_cmake
-            cmake -DSKIP_MGIZA=ON -DCMAKE_INSTALL_PREFIX=/usr ..
+            cmake -DCMAKE_INSTALL_PREFIX=/usr ..
             make -j
             sudo make install
       -  name: Run tests

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
    build_and_testing:
       name: Build and testing
       runs-on: ubuntu-20.04
-      timeout-minutes: 1440
+      timeout-minutes: 360
       steps:
       -  name: Install required linux packages
          run: |
@@ -99,7 +99,7 @@ jobs:
                   echo ""
                done < "${WORK}/data/fails.log"
             else
-               >&2 echo "ERROR: could not find the file which contain the fails, and should exist"
+               >&2 echo "ERROR: could not find the file with the detailed fails"
                exit 1
             fi
       -  name: Upload sent.gz files (artifacts)

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,12 +5,10 @@ on:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
    pull_request:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
 
 env:
    WORK: ${{ github.workspace }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -5,12 +5,10 @@ on:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
    pull_request:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
 
 env:
    WORK: ${{ github.workspace }}
@@ -42,10 +40,22 @@ jobs:
          run: |
             # Tmp workaround: we install the package in the same environment (waiting answers: https://github.com/conda-incubator/setup-miniconda/issues/221)
 
-            bitextor_package=$(ls "$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64" | grep ^bitextor.*[.]tar[.]bz2$ | sort -r | head -n 1)
+            bitextor_pkg_prefix="$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64"
+            bitextor_pkg=$(ls "$bitextor_pkg_prefix" | grep ^bitextor.*[.]tar[.]bz2$ | sort -r | head -n 1)
 
-            conda install -y "$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64/$bitextor_package"
-            conda update -y --all
+            if [[ -z "$bitextor_pkg" ]]; then
+               >&2 echo "ERROR: could not find the package"
+
+               if [[ ! -d "$bitextor_pkg_prefix" ]]; then
+                  >&2 echo "ERROR: dir '$bitextor_pkg_prefix' does not exist"
+               else
+                  ls "$bitextor_pkg_prefix"
+               fi
+
+               exit 1
+            fi
+
+            conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Run tests

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -56,6 +56,7 @@ jobs:
             fi
 
             conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
+            conda update -y --all # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Run tests

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -31,7 +31,7 @@ jobs:
             python-version: 3.8.5
             activate-environment: bitextor-build
             channels: conda-forge,bitextor,bioconda,dmnapolitano,esarrias
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v3
          with:
             submodules: 'recursive'
       -  name: Create Bitextor conda build

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -17,7 +17,7 @@ jobs:
    conda_build_testing:
       name: Build and testing
       runs-on: ubuntu-20.04
-      timeout-minutes: 300
+      timeout-minutes: 360
       defaults:
          run:
             shell: bash -l {0} # Necessary for https://github.com/conda-incubator/setup-miniconda
@@ -92,7 +92,7 @@ jobs:
                   echo ""
                done < "${WORK}/data/fails.log"
             else
-               >&2 echo "ERROR: could not find the file which contain the fails, and should exist"
+               >&2 echo "ERROR: could not find the file with the detailed fails"
                exit 1
             fi
       -  name: Upload sent.gz files (artifacts)

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -2,8 +2,11 @@ name: Build and test conda environment
 
 on:
    push:
-      branches:
-         - master
+      paths-ignore:
+         - '**.md'
+         - 'docs/**'
+         - 'img/**'
+   pull_request:
       paths-ignore:
          - '**.md'
          - 'docs/**'

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -56,7 +56,7 @@ jobs:
             fi
 
             conda install --offline -y "${bitextor_pkg_prefix}/$bitextor_pkg"
-            conda update -y --only-deps # Necessary in order to install dependencies from local builds
+            conda update -y --only-deps bitextor # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Run tests

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -28,7 +28,7 @@ jobs:
             python-version: 3.8.5
             activate-environment: bitextor-build
             channels: conda-forge,bitextor,bioconda,dmnapolitano,esarrias
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          with:
             submodules: 'recursive'
       -  name: Create Bitextor conda build

--- a/.github/workflows/conda-build-test.yaml
+++ b/.github/workflows/conda-build-test.yaml
@@ -55,8 +55,8 @@ jobs:
                exit 1
             fi
 
-            conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
-            conda update -y --all # Necessary in order to install dependencies from local builds
+            conda install --offline -y "${bitextor_pkg_prefix}/$bitextor_pkg"
+            conda update -y --only-deps # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Run tests

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -47,7 +47,7 @@ on:
 env:
    WORK: ${{ github.workspace }}
    CONDA_PACKAGE: ${{ github.event.inputs.conda_package || 'bitextor' }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
+   CREATE_BUILD: ${{ github.event.inputs.create_build || true }}
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    BUILD_REF: ${{ github.event.inputs.build_ref || 'master' }}
 

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -106,7 +106,7 @@ jobs:
             fi
 
             conda install --offline -y "${bitextor_pkg_prefix}/$bitextor_pkg"
-            conda update -y --only-deps # Necessary in order to install dependencies from local builds
+            conda update -y --only-deps bitextor # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Install Bitextor from repo

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -47,7 +47,7 @@ on:
 env:
    WORK: ${{ github.workspace }}
    CONDA_PACKAGE: ${{ github.event.inputs.conda_package || 'bitextor' }}
-   CREATE_BUILD: ${{ fromJSON(github.event.inputs.create_build || 'true') }}
+   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    BUILD_REF: ${{ github.event.inputs.build_ref || 'master' }}
 
@@ -88,17 +88,17 @@ jobs:
             activate-environment: bitextor-tests
             channels: conda-forge,bitextor,bioconda,dmnapolitano,esarrias
       -  uses: actions/checkout@v3
-         if: ${{ env.CREATE_BUILD }}
+         if: ${{ env.CREATE_BUILD == 'true' }}
          with:
             submodules: 'recursive'
             ref: ${{ env.BUILD_REF }}
       -  name: Create Bitextor conda build
-         if: ${{ env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          working-directory: ./conda-build
          run: |
             ./make_build.sh -n bitextor-pkg -e bitextor-pkg-build -p 3.8 -s -r
       -  name: Install Bitextor locally
-         if: ${{ env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             # Tmp workaround: we install the package in the same environment (waiting answers: https://github.com/conda-incubator/setup-miniconda/issues/221)
 
@@ -109,7 +109,7 @@ jobs:
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Install Bitextor from repo
-         if: ${{ !env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             v="${{ env.CONDA_PACKAGE }}"
 

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -47,7 +47,7 @@ on:
 env:
    WORK: ${{ github.workspace }}
    CONDA_PACKAGE: ${{ github.event.inputs.conda_package || 'bitextor' }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || true }}
+   CREATE_BUILD: ${{ fromJSON(github.event.inputs.create_build || 'true') }}
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    BUILD_REF: ${{ github.event.inputs.build_ref || 'master' }}
 

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -105,8 +105,8 @@ jobs:
                exit 1
             fi
 
-            conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
-            conda update -y --all # Necessary in order to install dependencies from local builds
+            conda install --offline -y "${bitextor_pkg_prefix}/$bitextor_pkg"
+            conda update -y --only-deps # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Install Bitextor from repo

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             python-version: 3.8.5
             activate-environment: bitextor-tests
             channels: conda-forge,bitextor,bioconda,dmnapolitano,esarrias
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          if: ${{ env.CREATE_BUILD == 'true' }}
          with:
             submodules: 'recursive'

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -106,6 +106,7 @@ jobs:
             fi
 
             conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
+            conda update -y --all # Necessary in order to install dependencies from local builds
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Install Bitextor from repo

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -43,7 +43,7 @@ jobs:
    tests:
       name: ${{ matrix.name }}
       runs-on: ubuntu-20.04
-      timeout-minutes: 1440
+      timeout-minutes: 360
       strategy:
          fail-fast: false # Continue even when a matrix job fails in order to detect as many errors as possible
          matrix:
@@ -117,7 +117,7 @@ jobs:
          id: tests
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |
-            "${CONDA_PREFIX}/bitextor/tests/run-tests.sh" -t ${{ matrix.test_id }} -w "$WORK"
+            "${CONDA_PREFIX}/bitextor/tests/run-tests.sh" -t ${{ matrix.test_id }} -w "$WORK" -j 4
       -  name: Print log of tests which failed
          # https://github.com/actions/runner/issues/1173
          #if: ${{ steps.tests.conclusion != 'success' }}
@@ -146,7 +146,7 @@ jobs:
                   echo ""
                done < "${WORK}/data/fails.log"
             else
-               >&2 echo "ERROR: could not find the file which contain the fails, and should exist"
+               >&2 echo "ERROR: could not find the file with the detailed fails"
             fi
       -  name: Upload sent.gz files (artifacts)
          if: ${{ always() }}

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -6,24 +6,12 @@ on:
    workflow_dispatch:
       inputs:
          conda_package:
-            description: 'Package which will be installed'
+            description: 'Package from repo. Syntax: pkg[==version[=build]]'
             required: false
             default: 'bitextor'
-            type: choice
-            options:
-               - 'bitextor'
-               - 'bitextor-nightly'
-         conda_version:
-            description: 'Version which will be looked for'
-            required: false
-            default: ''
-         conda_build:
-            description: 'Build which will be looked for'
-            required: false
-            default: ''
          create_build:
             type: boolean
-            description: 'Create build instead of downloading last package available'
+            description: 'Create build (i.e. do not pull pkg from repo)'
             default: true
          build_ref:
             description: 'Ref to use for local build (i.e. branch, tag or commit)'
@@ -102,26 +90,28 @@ jobs:
          run: |
             # Tmp workaround: we install the package in the same environment (waiting answers: https://github.com/conda-incubator/setup-miniconda/issues/221)
 
-            bitextor_package=$(ls "$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64" | grep ^bitextor.*[.]tar[.]bz2$ | sort -r | head -n 1)
+            bitextor_pkg_prefix="$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64"
+            bitextor_pkg=$(ls "$bitextor_pkg_prefix" | grep ^bitextor.*[.]tar[.]bz2$ | sort -r | head -n 1)
 
-            conda install -y "$CONDA_PREFIX/../../envs/bitextor-pkg-build/conda-bld/linux-64/$bitextor_package"
-            conda update -y --all
+            if [[ -z "$bitextor_pkg" ]]; then
+               >&2 echo "ERROR: could not find the package"
+
+               if [[ ! -d "$bitextor_pkg_prefix" ]]; then
+                  >&2 echo "ERROR: dir '$bitextor_pkg_prefix' does not exist"
+               else
+                  ls "$bitextor_pkg_prefix"
+               fi
+
+               exit 1
+            fi
+
+            conda install -y "${bitextor_pkg_prefix}/$bitextor_pkg"
             command -v "bitextor" || \
                (>&2 echo "Binary 'bitextor' not available"; exit 1)
       -  name: Install Bitextor from repo
          if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
-            v="${{ env.CONDA_PACKAGE }}"
-
-            if [[ "${{ github.event.inputs.conda_version }}" != "" ]]; then
-               v="${v}=${{ github.event.inputs.conda_version }}"
-
-               if [[ "${{ github.event.inputs.conda_build }}" != "" ]]; then
-                  v="${v}=${{ github.event.inputs.conda_build }}"
-               fi
-            fi
-
-            conda install -y "$v"
+            conda install -y "${{ env.CONDA_PACKAGE }}"
       -  name: Run tests
          id: tests
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}

--- a/.github/workflows/conda-intensive-tests.yaml
+++ b/.github/workflows/conda-intensive-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             python-version: 3.8.5
             activate-environment: bitextor-tests
             channels: conda-forge,bitextor,bioconda,dmnapolitano,esarrias
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v3
          if: ${{ env.CREATE_BUILD == 'true' }}
          with:
             submodules: 'recursive'

--- a/.github/workflows/deferred.yaml
+++ b/.github/workflows/deferred.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v3
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/deferred.yaml
+++ b/.github/workflows/deferred.yaml
@@ -17,7 +17,7 @@ jobs:
    build_and_testing:
       name: Deferred crawling testing
       runs-on: ubuntu-20.04
-      timeout-minutes: 1440
+      timeout-minutes: 360
       steps:
       -  name: Install required linux packages
          run: |

--- a/.github/workflows/deferred.yaml
+++ b/.github/workflows/deferred.yaml
@@ -63,7 +63,7 @@ jobs:
       -  name: Compiling bitextor and submodules
          run: |
             mkdir build_cmake && cd build_cmake
-            cmake -DSKIP_MGIZA=ON -DCMAKE_INSTALL_PREFIX=/usr ..
+            cmake -DCMAKE_INSTALL_PREFIX=/usr ..
             make -j
             sudo make install
       -  name: Run tests

--- a/.github/workflows/deferred.yaml
+++ b/.github/workflows/deferred.yaml
@@ -5,12 +5,10 @@ on:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
    pull_request:
       paths-ignore:
          - '**.md'
          - 'docs/**'
-         - 'img/**'
 
 env:
    WORK: ${{ github.workspace }}

--- a/.github/workflows/deferred.yaml
+++ b/.github/workflows/deferred.yaml
@@ -41,7 +41,7 @@ jobs:
             java-version: 8
             java-package: jdk
             architecture: x64
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          with:
             submodules: 'recursive'
       -  name: Install additional python requirements

--- a/.github/workflows/docker-build-and-test.yaml
+++ b/.github/workflows/docker-build-and-test.yaml
@@ -1,99 +1,44 @@
-name: Intensive tests with docker
+name: Build and test docker environment
 
 on:
-   schedule:
-      - cron: '0 3 * * 0'
-   workflow_dispatch:
-      inputs:
-         docker_tag:
-            description: 'Tag which will be looked for'
-            required: false
-            default: 'edge'
-         create_build:
-            type: boolean
-            description: 'Create build instead of downloading an image'
-            default: true
-         build_ref:
-            description: 'Ref to use when local build is created (i.e. branch, tag or commit)'
-            default: 'master'
-         test_id:
-            description: 'Run specific test ID'
-            required: false
-            default: 'all'
-            type: choice
-            options:
-               - 'all'
-               - '0x01'
-               - '0x02'
-               - '0x04'
-               - '0x08'
-               - '0x10'
-               - '0x20'
-               - '0x40'
-               - '0x80'
+   push:
+      paths-ignore:
+         - '**.md'
+         - 'docs/**'
+   pull_request:
+      paths-ignore:
+         - '**.md'
+         - 'docs/**'
 
 env:
    WORK: ${{ github.workspace }}
    WORK_DOCKER: '/home/docker'
-   TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
-   DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
+   DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.sha[:7]) }}
 
 jobs:
-   tests:
-      name: ${{ matrix.name }}
+   docker_build_testing:
+      name: Build and testing
       runs-on: ubuntu-20.04
       timeout-minutes: 360
-      strategy:
-         fail-fast: false # Continue even when a matrix job fails in order to detect as many errors as possible
-         matrix:
-            include:
-               - name: Tests MT
-                 test_id: "0x01"
-               - name: Tests dictionary based
-                 test_id: "0x02"
-               - name: Tests generate dictionary
-                 test_id: "0x04"
-               - name: Tests generate bicleaner model
-                 test_id: "0x08"
-               - name: Tests generate dictionary and bicleaner model
-                 test_id: "0x10"
-               - name: Tests combining dictionaries and MT
-                 test_id: "0x20"
-               - name: Tests neural
-                 test_id: "0x40"
-               - name: Other tests
-                 test_id: "0x80"
       steps:
       -  uses: actions/checkout@v3
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          with:
             submodules: 'recursive'
-            ref: ${{ env.BUILD_REF }}
       -  name: Set up Docker Buildx
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          uses: docker/setup-buildx-action@v2
       -  name: Test docker
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |
             docker pull hello-world > /dev/null
             docker run --rm hello-world > /dev/null
       -  name: Build image
-         if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             docker build --rm --tag "$DOCKER_IMAGE_TAG" .
-      -  name: Pull image
-         if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         run: |
-            docker pull "$DOCKER_IMAGE_TAG"
       -  name: Info
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |
             df -h
             docker image ls -a --digests || >&2 echo "WARNING: could not run 'docker image ls'"
             docker buildx du --verbose || >&2 echo "WARNING: could not run 'docker buildx du'"
       -  name: Run
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |
             mkdir "${WORK}/docker-volume"
 
@@ -105,7 +50,7 @@ jobs:
                --name bitextor \
                --entrypoint /bin/bash --rm \
                "${DOCKER_IMAGE_TAG}" \
-               -c 'bitextor/tests/run-tests.sh -t ${{ matrix.test_id }} -j 4; \
+               -c 'bitextor/tests/run-tests-min.sh -j 4; \
                    cp -f '"${WORK_DOCKER}/data/fails.log"' '"${WORK_DOCKER}/volume"' && \
                    rm -rf '"${WORK_DOCKER}/volume/reports"' && \
                    cp -r '"${WORK_DOCKER}/reports"' '"${WORK_DOCKER}/volume"' && \

--- a/.github/workflows/docker-build-and-test.yaml
+++ b/.github/workflows/docker-build-and-test.yaml
@@ -13,7 +13,7 @@ on:
 env:
    WORK: ${{ github.workspace }}
    WORK_DOCKER: '/home/docker'
-   DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.sha[:7]) }}
+   DOCKER_IMAGE_NAME: 'bitextor/bitextor'
 
 jobs:
    docker_build_testing:
@@ -24,6 +24,14 @@ jobs:
       -  uses: actions/checkout@v3
          with:
             submodules: 'recursive'
+      -  name: Docker image tag
+         id: image_tag
+         run: |
+            # Provided name and short SHA
+            tag="${{ env.DOCKER_IMAGE_NAME }}:${GITHUB_SHA:0:7}"
+
+            echo "Tag: $tag"
+            echo "::set-output name=tag::$tag"
       -  name: Set up Docker Buildx
          uses: docker/setup-buildx-action@v2
       -  name: Test docker
@@ -32,7 +40,7 @@ jobs:
             docker run --rm hello-world > /dev/null
       -  name: Build image
          run: |
-            docker build --rm --tag "$DOCKER_IMAGE_TAG" .
+            docker build --rm --tag "${{ steps.image_tag.outputs.tag }}" .
       -  name: Info
          run: |
             df -h
@@ -49,7 +57,7 @@ jobs:
                -v "${WORK}/docker-volume:${WORK_DOCKER}/volume" \
                --name bitextor \
                --entrypoint /bin/bash --rm \
-               "${DOCKER_IMAGE_TAG}" \
+               "${{ steps.image_tag.outputs.tag }}" \
                -c 'bitextor/tests/run-tests-min.sh -j 4; \
                    cp -f '"${WORK_DOCKER}/data/fails.log"' '"${WORK_DOCKER}/volume"' && \
                    rm -rf '"${WORK_DOCKER}/volume/reports"' && \

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -37,7 +37,7 @@ env:
    WORK_DOCKER: '/home/docker'
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ (github.event.inputs.create_build == 'true') || 'true' }}
+   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
    DOCKER_IMAGE_PULL: ${{ (github.event.inputs.create_build == 'false') || 'false' }}
 
 jobs:

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -96,6 +96,7 @@ jobs:
             mkdir "${WORK}/docker-volume"
 
             # Run tests with docker
+            docker_exit_code=$(
             docker run \
                -e CI="$CI" \
                -v "${WORK}/docker-volume:${WORK_DOCKER}/volume" \
@@ -106,7 +107,13 @@ jobs:
                    cp -f '"${WORK_DOCKER}/data/fails.log"' '"${WORK_DOCKER}/volume"' && \
                    rm -rf '"${WORK_DOCKER}/volume/reports"' && \
                    cp -r '"${WORK_DOCKER}/reports"' '"${WORK_DOCKER}/volume"' && \
-                   cp -r '"${WORK_DOCKER}/permanent"' '"${WORK_DOCKER}/volume"'' &> ./tests_output
+                   cp -r '"${WORK_DOCKER}/permanent"' '"${WORK_DOCKER}/volume"'' \
+               &> ./tests_output \
+               && echo $? || echo $?)
+
+            if [[ "$docker_exit_code" != "0" ]]; then
+               >&2 echo "WARNING: something went wrong while tests were running"
+            fi
 
             cat ./tests_output
 

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -80,7 +80,7 @@ jobs:
             docker run --rm hello-world > /dev/null
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@master
+         uses: docker/build-push-action@2.10.0
          with:
             context: .
             load: true # If true, once the image has been pulled or built, it will be available from docker

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -80,7 +80,7 @@ jobs:
             docker run --rm hello-world > /dev/null
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@v3.1.0
+         uses: docker/build-push-action@master
          with:
             context: .
             load: true # If true, once the image has been pulled or built, it will be available from docker

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -80,7 +80,7 @@ jobs:
             docker run --rm hello-world > /dev/null
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@v3
+         uses: docker/build-push-action@v3.1.0
          with:
             context: .
             load: true # If true, once the image has been pulled or built, it will be available from docker

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -74,20 +74,23 @@ jobs:
       -  name: Set up Docker Buildx
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          uses: docker/setup-buildx-action@v2
-      -  name: Build and export to Docker
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
-         uses: docker/build-push-action@v3
-         with:
-            context: .
-            load: true # If true, once the image has been pulled or built, it will be available from docker
-            pull: ${{ env.DOCKER_IMAGE_PULL }}
-            push: false
-            tags: ${{ env.DOCKER_IMAGE_TAG }}
       -  name: Test docker
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |
             docker pull hello-world > /dev/null
             docker run --rm hello-world > /dev/null
+      -  name: Build and export to Docker
+         if: ${{ env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         uses: docker/build-push-action@v3
+         with:
+            context: .
+            load: true # If true, once the image has been pulled or built, it will be available from docker
+            push: false
+            tags: ${{ env.DOCKER_IMAGE_TAG }}
+      -  name: Pull image
+         if: ${{ env.DOCKER_IMAGE_PULL && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         run: |
+            docker pull "$DOCKER_IMAGE_TAG"
       -  name: Run
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -38,7 +38,7 @@ env:
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
    CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
-   DOCKER_IMAGE_PULL: ${{ (!github.event.inputs.create_build) || 'false' }}
+   DOCKER_IMAGE_PULL: ${{ !(github.event.inputs.create_build || 'false') }}
 
 jobs:
    tests:

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -65,7 +65,7 @@ jobs:
                - name: Other tests
                  test_id: "0x80"
       steps:
-      -  uses: actions/checkout@v3.0.2
+      -  uses: actions/checkout@v2
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          with:
             submodules: 'recursive'

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -90,6 +90,12 @@ jobs:
          if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             docker pull "$DOCKER_IMAGE_TAG"
+      -  name: Docker info
+         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
+         run: |
+            docker image ls -a --digests
+            docker buildx du --verbose
+            df -h
       -  name: Run
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          run: |

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -80,7 +80,7 @@ jobs:
             docker run --rm hello-world > /dev/null
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@2.10.0
+         uses: docker/build-push-action@v2.10.0
          with:
             context: .
             load: true # If true, once the image has been pulled or built, it will be available from docker

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -37,8 +37,8 @@ env:
    WORK_DOCKER: '/home/docker'
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
-   DOCKER_IMAGE_PULL: ${{ (github.event.inputs.create_build == 'false') || 'false' }}
+   CREATE_BUILD: ${{ github.event.inputs.create_build || true }}
+   DOCKER_IMAGE_PULL: ${{ (github.event.inputs.create_build == false) || false }}
 
 jobs:
    tests:

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -65,11 +65,6 @@ jobs:
                - name: Other tests
                  test_id: "0x80"
       steps:
-      -  uses: actions/checkout@v2
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
-         with:
-            submodules: 'recursive'
-            ref: ${{ env.BUILD_REF }}
       -  name: Set up Docker Buildx
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          uses: docker/setup-buildx-action@v2
@@ -78,9 +73,14 @@ jobs:
          run: |
             docker pull hello-world > /dev/null
             docker run --rm hello-world > /dev/null
+      -  uses: actions/checkout@v3.0.2
+         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
+         with:
+            submodules: 'recursive'
+            ref: ${{ env.BUILD_REF }}
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@v2.10.0
+         uses: docker/build-push-action@v3
          with:
             context: .
             load: true # If true, once the image has been pulled or built, it will be available from docker

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -37,8 +37,7 @@ env:
    WORK_DOCKER: '/home/docker'
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || true }}
-   DOCKER_IMAGE_PULL: ${{ (github.event.inputs.create_build == false) || false }}
+   CREATE_BUILD: ${{ fromJSON(github.event.inputs.create_build || 'true') }}
 
 jobs:
    tests:
@@ -88,7 +87,7 @@ jobs:
             push: false
             tags: ${{ env.DOCKER_IMAGE_TAG }}
       -  name: Pull image
-         if: ${{ env.DOCKER_IMAGE_PULL && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ !env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             docker pull "$DOCKER_IMAGE_TAG"
       -  name: Run

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -37,7 +37,7 @@ env:
    WORK_DOCKER: '/home/docker'
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ fromJSON(github.event.inputs.create_build || 'true') }}
+   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
 
 jobs:
    tests:
@@ -79,7 +79,7 @@ jobs:
             docker pull hello-world > /dev/null
             docker run --rm hello-world > /dev/null
       -  name: Build and export to Docker
-         if: ${{ env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          uses: docker/build-push-action@v3
          with:
             context: .
@@ -87,7 +87,7 @@ jobs:
             push: false
             tags: ${{ env.DOCKER_IMAGE_TAG }}
       -  name: Pull image
-         if: ${{ !env.CREATE_BUILD && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
+         if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |
             docker pull "$DOCKER_IMAGE_TAG"
       -  name: Run

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -65,6 +65,11 @@ jobs:
                - name: Other tests
                  test_id: "0x80"
       steps:
+      -  uses: actions/checkout@v3
+         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
+         with:
+            submodules: 'recursive'
+            ref: ${{ env.BUILD_REF }}
       -  name: Set up Docker Buildx
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          uses: docker/setup-buildx-action@v2
@@ -73,19 +78,10 @@ jobs:
          run: |
             docker pull hello-world > /dev/null
             docker run --rm hello-world > /dev/null
-      -  uses: actions/checkout@v3.0.2
-         if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
-         with:
-            submodules: 'recursive'
-            ref: ${{ env.BUILD_REF }}
       -  name: Build and export to Docker
          if: ${{ env.CREATE_BUILD == 'true' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
-         uses: docker/build-push-action@v3
-         with:
-            context: .
-            load: true # If true, once the image has been pulled or built, it will be available from docker
-            push: false
-            tags: ${{ env.DOCKER_IMAGE_TAG }}
+         run: |
+            docker build --tag "$DOCKER_IMAGE_TAG" .
       -  name: Pull image
          if: ${{ env.CREATE_BUILD == 'false' && (env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id) }}
          run: |

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -37,8 +37,8 @@ env:
    WORK_DOCKER: '/home/docker'
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
-   CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
-   DOCKER_IMAGE_PULL: ${{ !(github.event.inputs.create_build || 'false') }}
+   CREATE_BUILD: ${{ (github.event.inputs.create_build == 'true') || 'true' }}
+   DOCKER_IMAGE_PULL: ${{ (github.event.inputs.create_build == 'false') || 'false' }}
 
 jobs:
    tests:

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -65,7 +65,7 @@ jobs:
                - name: Other tests
                  test_id: "0x80"
       steps:
-      -  uses: actions/checkout@v3
+      -  uses: actions/checkout@v3.0.2
          if: ${{ env.TEST_ID == 'all' || env.TEST_ID == matrix.test_id }}
          with:
             submodules: 'recursive'

--- a/.github/workflows/docker-intensive-tests.yaml
+++ b/.github/workflows/docker-intensive-tests.yaml
@@ -38,7 +38,7 @@ env:
    TEST_ID: ${{ github.event.inputs.test_id || 'all' }}
    DOCKER_IMAGE_TAG: ${{ format('bitextor/bitextor:{0}', github.event.inputs.docker_tag || 'edge') }}
    CREATE_BUILD: ${{ github.event.inputs.create_build || 'true' }}
-   DOCKER_IMAGE_PULL: ${{ !github.event.inputs.create_build || 'false' }}
+   DOCKER_IMAGE_PULL: ${{ (!github.event.inputs.create_build) || 'false' }}
 
 jobs:
    tests:

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -1378,21 +1378,48 @@ rule aggregate_bifixer:
         """ echo {input} | tr ' ' '\n' > {output} """
 
 
-rule bicleaner_train_model:
+rule bicleaner_train_model_classic:
     """
-    Train bicleaner model
+    Train bicleaner model (flavour: classic)
     """
     input:
         corpus_l1=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG1),
         corpus_l2=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG2),
-        # Bicleaner
         e2f=optional_str_input(f"{DIC}.lex.e2f.gz", BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
         f2e=optional_str_input(f"{DIC}.lex.f2e.gz", BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
         vcb1=optional_str_input(f"{mgizaModelDir}/corpus.{LANG1}.filtered.vcb.gz",
                                 BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
         vcb2=optional_str_input(f"{mgizaModelDir}/corpus.{LANG2}.filtered.vcb.gz",
                                 BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
-        # Bicleaner AI
+    output:
+        model=f"{BICLEANER_MODEL}.classic",
+    params:
+        training_corpus=temp(f"{TMPDIR}/bicleaner_train/training_parallel_corpus.{LANG1}_{LANG2}"),
+        # Bicleaner
+        classifier=f"{'/'.join(BICLEANER_MODEL.split('/')[:-1])}/{LANG1}-{LANG2}.classifier",
+        model=BICLEANER_MODEL,
+    shell:
+        """
+        echo "Training corpus: {params.training_corpus}"
+        mkdir -p "{TMPDIR}/bicleaner_train/bicleaner-ai"
+        paste <(zcat {input.corpus_l1}) <(zcat {input.corpus_l2}) > {params.training_corpus}
+
+        {PROFILING} bicleaner-train {params.training_corpus} -S "{WORDTOK1}" -T "{WORDTOK2}" --treat_oovs \
+            --normalize_by_length -s {LANG1} -t {LANG2} -d {input.e2f} -D {input.f2e} -f {input.vcb1} \
+            -F {input.vcb2} -c {params.classifier} -m {params.model} --classifier_type random_forest \
+            --seed 71213
+
+        ln -s "{params.model}" "{output.model}"
+        """
+
+
+rule bicleaner_train_model_ai:
+    """
+    Train bicleaner model (flavour: ai)
+    """
+    input:
+        corpus_l1=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG1),
+        corpus_l2=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG2),
         mono_l1=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG1)),
                                    BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
         mono_l2=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG2)),
@@ -1402,7 +1429,7 @@ rule bicleaner_train_model:
         dev_corpus_l2=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_DEV_CORPUS_PREFIX, lang=LANG2)),
                                          BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
     output:
-        model=BICLEANER_MODEL,
+        model=f"{BICLEANER_MODEL}.ai",
     params:
         training_corpus=temp(f"{TMPDIR}/bicleaner_train/training_parallel_corpus.{LANG1}_{LANG2}"),
         # Bicleaner
@@ -1413,49 +1440,45 @@ rule bicleaner_train_model:
         mono_corpus=temp(f"{TMPDIR}/bicleaner_train/bicleaner-ai/mono_corpus.{LANG1}_{LANG2}"),
         metadata_dir='/'.join(BICLEANER_MODEL.split('/')[:-1]),
         ai_metadata=f"{'/'.join(BICLEANER_MODEL.split('/')[:-1])}/metadata.yaml",
+        model=BICLEANER_MODEL,
     shell:
         """
         echo "Training corpus: {params.training_corpus}"
         mkdir -p "{TMPDIR}/bicleaner_train/bicleaner-ai"
         paste <(zcat {input.corpus_l1}) <(zcat {input.corpus_l2}) > {params.training_corpus}
 
-        if [[ "{BICLEANER_FLAVOUR}" == "classic" ]]; then
-            {PROFILING} bicleaner-train {params.training_corpus} -S "{WORDTOK1}" -T "{WORDTOK2}" --treat_oovs \
-                --normalize_by_length -s {LANG1} -t {LANG2} -d {input.e2f} -D {input.f2e} -f {input.vcb1} \
-                -F {input.vcb2} -c {params.classifier} -m {output.model} --classifier_type random_forest \
-                --seed 71213
-        elif [[ "{BICLEANER_FLAVOUR}" == "ai" ]]; then
-            # Target lang frequency
-            echo "Frequency file (lang={LANG2}): {params.tfreq}"
-            zcat {input.mono_l2} \
-                | {WORDTOK2} \
-                | awk '{{print tolower($0)}}' \
-                | tr ' ' '\n' \
-                | LC_ALL=C sort | uniq -c \
-                | LC_ALL=C sort -nr \
-                | grep -v "[[:space:]]*1" \
-                | pigz -c > {params.tfreq}
+        # Target lang frequency
+        echo "Frequency file (lang={LANG2}): {params.tfreq}"
+        zcat {input.mono_l2} \
+            | {WORDTOK2} \
+            | awk '{{print tolower($0)}}' \
+            | tr ' ' '\n' \
+            | LC_ALL=C sort | uniq -c \
+            | LC_ALL=C sort -nr \
+            | grep -v "[[:space:]]*1" \
+            | pigz -c > {params.tfreq}
 
-            # Dev corpus
-            echo "Dev corpus: {params.dev_corpus}"
-            paste <(zcat {input.dev_corpus_l1}) <(zcat {input.dev_corpus_l2}) > {params.dev_corpus}
+        # Dev corpus
+        echo "Dev corpus: {params.dev_corpus}"
+        paste <(zcat {input.dev_corpus_l1}) <(zcat {input.dev_corpus_l2}) > {params.dev_corpus}
 
-            # Mono
-            echo "Mono corpus: {params.mono_corpus}"
+        # Mono
+        echo "Mono corpus: {params.mono_corpus}"
 
-            mono_l1_nolines=$(zcat {input.mono_l1} | wc -l)
-            mono_l2_nolines=$(zcat {input.mono_l2} | wc -l)
-            mono_min_nolines=$([[ $mono_l1_nolines -gt $mono_l2_nolines ]] && echo "$mono_l2_nolines" || echo "$mono_l1_nolines")
+        mono_l1_nolines=$(zcat {input.mono_l1} | wc -l)
+        mono_l2_nolines=$(zcat {input.mono_l2} | wc -l)
+        mono_min_nolines=$([[ $mono_l1_nolines -gt $mono_l2_nolines ]] && echo "$mono_l2_nolines" || echo "$mono_l1_nolines")
 
-            head -n $mono_min_nolines <(zcat {input.mono_l1}) > {params.mono_corpus}
-            head -n $mono_min_nolines <(zcat {input.mono_l2}) >> {params.mono_corpus}
+        head -n $mono_min_nolines <(zcat {input.mono_l1}) > {params.mono_corpus}
+        head -n $mono_min_nolines <(zcat {input.mono_l2}) >> {params.mono_corpus}
 
-            # Train
-            {PROFILING} bicleaner-ai-train -S "{WORDTOK1}" -T "{WORDTOK2}" -s {LANG1} -t {LANG2} -F {params.tfreq} \
-                -m {params.metadata_dir} --classifier_type dec_attention --parallel_train {params.training_corpus} \
-                --parallel_valid {params.dev_corpus} --mono_train {params.mono_corpus} --seed 71213 && \
-                    mv {params.ai_metadata} {output.model}
-        fi
+        # Train
+        {PROFILING} bicleaner-ai-train -S "{WORDTOK1}" -T "{WORDTOK2}" -s {LANG1} -t {LANG2} -F {params.tfreq} \
+            -m {params.metadata_dir} --classifier_type dec_attention --parallel_train {params.training_corpus} \
+            --parallel_valid {params.dev_corpus} --mono_train {params.mono_corpus} --seed 71213 && \
+                mv {params.ai_metadata} {params.model}
+
+        ln -s "{params.model}" "{output.model}"
         """
 
 
@@ -1468,7 +1491,7 @@ rule bicleaner:
     """
     input:
         bifixer=rules.bifixer.output if BIFIXER else rules.bifixer.input.segalign,
-        model=BICLEANER_MODEL,
+        model=f"{BICLEANER_MODEL}.{BICLEANER_FLAVOUR}",
     output:
         f"{TRANSIENT}/{LANG1}_{LANG2}/07_02.bicleaner/{{batch}}.gz",
     params:

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -1400,12 +1400,10 @@ rule bicleaner_train_model_classic:
     input:
         corpus_l1=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG1),
         corpus_l2=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG2),
-        e2f=optional_str_input(f"{DIC}.lex.e2f.gz", BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
-        f2e=optional_str_input(f"{DIC}.lex.f2e.gz", BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
-        vcb1=optional_str_input(f"{mgizaModelDir}/corpus.{LANG1}.filtered.vcb.gz",
-                                BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
-        vcb2=optional_str_input(f"{mgizaModelDir}/corpus.{LANG2}.filtered.vcb.gz",
-                                BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "classic"),
+        e2f=f"{DIC}.lex.e2f.gz",
+        f2e=f"{DIC}.lex.f2e.gz",
+        vcb1=f"{mgizaModelDir}/corpus.{LANG1}.filtered.vcb.gz",
+        vcb2=f"{mgizaModelDir}/corpus.{LANG2}.filtered.vcb.gz",
     output:
         model=f"{BICLEANER_MODEL}.classic",
     params:
@@ -1435,14 +1433,10 @@ rule bicleaner_train_model_ai:
     input:
         corpus_l1=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG1),
         corpus_l2=expand("{dataset}.{lang}.gz", dataset=BICLEANER_TRAINING_CORPUS_PREFIX, lang=LANG2),
-        mono_l1=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG1)),
-                                   BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
-        mono_l2=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG2)),
-                                   BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
-        dev_corpus_l1=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_DEV_CORPUS_PREFIX, lang=LANG1)),
-                                         BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
-        dev_corpus_l2=optional_str_input(' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_DEV_CORPUS_PREFIX, lang=LANG2)),
-                                         BICLEANER_GENERATE_MODEL and BICLEANER_FLAVOUR == "ai"),
+        mono_l1=' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG1)),
+        mono_l2=' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_MONO_CORPUS_PREFIX, lang=LANG2)),
+        dev_corpus_l1=' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_DEV_CORPUS_PREFIX, lang=LANG1)),
+        dev_corpus_l2=' '.join(expand("{dataset}.{lang}.gz", dataset=BICLEANER_AI_DEV_CORPUS_PREFIX, lang=LANG2)),
     output:
         model=f"{BICLEANER_MODEL}.ai",
     params:

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -199,6 +199,7 @@ except:
     pass
 
 DIC = return_dict_value_if_key(config, "dic", None)
+DIC_GENERATE = return_dict_value_if_key(config, "generateDic", False)
 
 #################################################################
 # SEGALIGN
@@ -279,7 +280,7 @@ if BIROAMER:
 
     if "biroamerImproveAlignmentCorpus" in config:
         BIROAMER_ALIGNMENT_CORPUS = f"-a {config['biroamerImproveAlignmentCorpus']}"
-if not BICLEANER_GENERATE_MODEL:
+if not BICLEANER_GENERATE_MODEL and not DIC_GENERATE:
     BICLEANER_TRAINING_CORPUS_PREFIX = []
     BICLEANER_AI_MONO_CORPUS_PREFIX = []
     BICLEANER_AI_DEV_CORPUS_PREFIX = []

--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -10,6 +10,7 @@ from bitextor.utils.common import (
     return_dict_value_if_key,
     get_snakemake_execution_mark,
     is_first_snakemake_execution,
+    path_exists,
 )
 
 valid, config = validate_args(config)
@@ -233,6 +234,20 @@ BICLEANER_AI_MONO_CORPUS_PREFIX = return_dict_value_if_key(config, "bicleanerMon
 BICLEANER_AI_DEV_CORPUS_PREFIX = return_dict_value_if_key(config, "bicleanerParallelCorpusDevPrefix", [])
 BICLEANER_BIN = "bicleaner-classify" if BICLEANER_FLAVOUR == "classic" else "bicleaner-ai-classify"
 BICLEANER_BIN += "-lite" if BICLEANER_MODEL_FLAVOUR == "lite" and BICLEANER_FLAVOUR == "classic" else ''
+
+if BICLEANER:
+    is_flavour_ai = BICLEANER_FLAVOUR == "ai"
+    path_exists_f=os.path.isdir if is_flavour_ai else os.path.isfile
+
+    # Create soft links based on the flavour if necessary
+    if is_flavour_ai:
+        # Get directory path from bicleaner model path
+        BICLEANER_MODEL = '/'.join(BICLEANER_MODEL.split('/')[:-1])
+
+    if path_exists(BICLEANER_MODEL, f=path_exists_f) and not path_exists(f"{BICLEANER_MODEL}.{BICLEANER_FLAVOUR}", f=path_exists_f):
+        os.symlink(f"{BICLEANER_MODEL}", f"{BICLEANER_MODEL}.{BICLEANER_FLAVOUR}")
+
+    # BICLEANER_MODEL will be a directory if is_flavour_ai else will be a file
 
 ELRC = return_dict_value_if_key(config, "elrc", False, pos_value=True)
 TMX = return_dict_value_if_key(config, "tmx", False, pos_value=True)
@@ -1432,14 +1447,11 @@ rule bicleaner_train_model_ai:
         model=f"{BICLEANER_MODEL}.ai",
     params:
         training_corpus=temp(f"{TMPDIR}/bicleaner_train/training_parallel_corpus.{LANG1}_{LANG2}"),
-        # Bicleaner
-        classifier=f"{'/'.join(BICLEANER_MODEL.split('/')[:-1])}/{LANG1}-{LANG2}.classifier",
-        # Bicleaner AI
         tfreq=temp(f"{TMPDIR}/bicleaner_train/bicleaner-ai/wordfreq_{LANG2}.gz"),
         dev_corpus=temp(f"{TMPDIR}/bicleaner_train/bicleaner-ai/dev_parallel_corpus.{LANG1}_{LANG2}"),
         mono_corpus=temp(f"{TMPDIR}/bicleaner_train/bicleaner-ai/mono_corpus.{LANG1}_{LANG2}"),
-        metadata_dir='/'.join(BICLEANER_MODEL.split('/')[:-1]),
-        ai_metadata=f"{'/'.join(BICLEANER_MODEL.split('/')[:-1])}/metadata.yaml",
+        metadata_dir=BICLEANER_MODEL,
+        ai_metadata=f"{BICLEANER_MODEL}/metadata.yaml",
         model=BICLEANER_MODEL,
     shell:
         """
@@ -1476,7 +1488,7 @@ rule bicleaner_train_model_ai:
         {PROFILING} bicleaner-ai-train -S "{WORDTOK1}" -T "{WORDTOK2}" -s {LANG1} -t {LANG2} -F {params.tfreq} \
             -m {params.metadata_dir} --classifier_type dec_attention --parallel_train {params.training_corpus} \
             --parallel_valid {params.dev_corpus} --mono_train {params.mono_corpus} --seed 71213 && \
-                mv {params.ai_metadata} {params.model}
+                mv {params.metadata_dir} {params.model}
 
         ln -s "{params.model}" "{output.model}"
         """
@@ -1497,11 +1509,12 @@ rule bicleaner:
     params:
         threads=THREADS["bicleaner"],
         parallel_args_sep="\\\"" if THREADS["bicleaner"] > 1 else "\"",
+        metadata_file=f"{BICLEANER_MODEL}.{BICLEANER_FLAVOUR}/metadata.yaml" if BICLEANER_FLAVOUR == "ai" else f"{BICLEANER_MODEL}.{BICLEANER_FLAVOUR}"
     threads: JOB_THREADS["bicleaner"]
     shell:
         """
         parallel_cmd=$([[ {params.threads} -gt 1 ]] && echo "parallel --gnu --halt 2 --pipe --j {params.threads} -k --header 1" || echo "")
-        slang=$(egrep "source_lang" {input.model} | cut -d " " -f 2)
+        slang=$(egrep "source_lang" {params.metadata_file} | cut -d " " -f 2)
         text_fields=$(head -1 <(zcat {input.bifixer}) \
             | python3 {WORKFLOW}/utils/cut_header.py -f src_text,trg_text --only-print-idxs \
             | tr -d '\n')

--- a/bitextor/other_scripts/bitextor_clean_text_align.py
+++ b/bitextor/other_scripts/bitextor_clean_text_align.py
@@ -16,7 +16,7 @@
 #  along with Bitextor.  If not, see <https://www.gnu.org/licenses/>.
 
 #
-# 1. All the alignments produced by bitextor-alignsegments are checked and those with an alignemnt confidence score
+# 1. All the alignments produced by bitextor-alignsegments are checked and those with an alignment confidence score
 # lower than a given threshold are discarded (also those unaligned segments are discarded)
 # 2. If, for a same document pair, a worng-alignment threshold is reached, the whole document pair is discarded
 #

--- a/conda-build/bitextor-nightly/meta.yaml
+++ b/conda-build/bitextor-nightly/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - boost
+    - boost-cpp 1.71.0 h8e57a91_1
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - boost
+    - boost-cpp 1.71.0 h8e57a91_1
     - java-jdk 8
     - xz
     - time

--- a/conda-build/bitextor-nightly/meta.yaml
+++ b/conda-build/bitextor-nightly/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - libboost 1.71 h97c9712_0
+    - boost-cpp
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - libboost 1.71 h97c9712_0
+    - boost-cpp
     - java-jdk 8
     - xz
     - time

--- a/conda-build/bitextor-nightly/meta.yaml
+++ b/conda-build/bitextor-nightly/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - boost-cpp
+    - boost
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - boost-cpp
+    - boost
     - java-jdk 8
     - xz
     - time

--- a/conda-build/bitextor-pkg/meta.yaml
+++ b/conda-build/bitextor-pkg/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - boost
+    - boost-cpp 1.71.0 h8e57a91_1
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - boost
+    - boost-cpp 1.71.0 h8e57a91_1
     - java-jdk 8
     - xz
     - time

--- a/conda-build/bitextor-pkg/meta.yaml
+++ b/conda-build/bitextor-pkg/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - libboost 1.71 h97c9712_0
+    - boost-cpp
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - libboost 1.71 h97c9712_0
+    - boost-cpp
     - java-jdk 8
     - xz
     - time

--- a/conda-build/bitextor-pkg/meta.yaml
+++ b/conda-build/bitextor-pkg/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - gxx_linux-64
     - go-cgo 1.13.5 h77d97cf_0
   host:
-    - boost-cpp
+    - boost
     - pip
     - setuptools
     - python {{ python }}
@@ -47,7 +47,7 @@ requirements:
     - pip
     - setuptools
     - python {{ python }}
-    - boost-cpp
+    - boost
     - java-jdk 8
     - xz
     - time

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -176,7 +176,7 @@ After crawling, the downloaded webs are processed to extract clean text, detect 
 After plain text extracion, the extracted data is sharded via [giashard](https://github.com/paracrawl/giashard) in order to create balanced jobs.
 Crawled websites and WARCs are distributed in shards for a more balanced processing, where each shard contains one or more complete domain(s).
 Shards in turn are split into batches of specified size to keep memory consumption in check.
-Document alignemnt works within shards, i.e. all documents in a shard will be compared for document alignment.
+Document alignment works within shards, i.e. all documents in a shard will be compared for document alignment.
 
 The following set of option define how that process is carried out.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -234,7 +234,7 @@ Sharding options:
 
 ## Sentence splitting
 
-By default a Python port of [Moses `split-sentences.perl`](https://pypi.org/project/sentence-splitter/) will be used for sentence splitting. This is recommened even without language support, since it is possible to provide custom non-breaking prefixes. External sentence splitter can by used via `sentence-splitters` parameter (less efficient).
+By default a Python wrapper of [Loomchild Segment](https://github.com/bitextor/loomchild-segment-py) will be used for sentence splitting.. This is recommened even without language support, since it is possible to provide custom non-breaking prefixes. External sentence splitter can by used via `sentence-splitters` parameter (less efficient).
 
 Custom sentence splitters must read plain text documents from standard input and write one sentence per line to standard output.
 

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -191,3 +191,20 @@ create_integrity_report()
             | xargs -I{} bash -c 'source "'${DIR}'/common.sh"; h=$(get_hash "{}"); echo "{}: ${h}"' >> "${INTEGRITY_REPORT}"
     done
 }
+
+init_test()
+{
+    # Export these variables to the global scope
+    TEST_ID="$1"
+    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+
+    mkdir -p "${TRANSIENT_DIR}"
+    pushd "${TRANSIENT_DIR}" > /dev/null
+}
+
+finish_test()
+{
+    annotate_and_echo_info_wrapper
+
+    popd > /dev/null
+}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -90,6 +90,7 @@ download_bicleaner_model()
     if [ ! -f "${output_file}" ]; then
         wget -q "${base}/${langs}.tar.gz" -P "${output}"
         tar xzf "${output_file}" -C "${output}"
+        ln -s "${output}/${langs}/${langs}.yaml" "${output}/${langs}/${langs}.yaml.classic" # Models are shared and parallel instances might break
     fi
 }
 
@@ -104,6 +105,7 @@ download_bicleaner_ai_model()
     if [ ! -f "${output_file}" ]; then
         wget -q "${base}/${flavour}-${langs}.tgz" -P "${output}"
         tar xzf "${output_file}" -C "${output}"
+        ln -s "${output}/${langs}" "${output}/${langs}.ai" # Models are shared and parallel instances might break
     fi
 }
 

--- a/tests/run-deferred-tests.sh
+++ b/tests/run-deferred-tests.sh
@@ -60,11 +60,8 @@ rm -f "${WORK}/output_reference/run-deferred-tests.tgz"
 
 # MT (id >= 10)
 ## MT (en-el)
-TEST_ID="10"
-TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+init_test "10"
 
-mkdir -p "${TRANSIENT_DIR}" && \
-pushd "${TRANSIENT_DIR}" > /dev/null && \
 ${BITEXTOR} \
   --config permanentDir="${WORK}/permanent/${TEST_ID}" \
     dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \

--- a/tests/run-tests-bitextor-only.sh
+++ b/tests/run-tests-bitextor-only.sh
@@ -100,40 +100,32 @@ wait
 # MT (id >= 10)
 ## MT (en-fr)
 (
-    TEST_ID="10"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "10"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
             deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 # Dictionary-based (id >= 20)
 ## Use dictionary pipeline (en-fr)
 (
-    TEST_ID="20"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "20"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" dataDir="${WORK}/data/${TEST_ID}" \
             transientDir="${TRANSIENT_DIR}" warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" \
             shards=1 batches=512 lang1=en lang2=fr documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" \
             sentenceAligner="hunalign" deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 wait
@@ -141,59 +133,47 @@ wait
 # MT and dictionary-based (id >= 60)
 ## Combine MT and dictionary (en-fr)
 (
-    TEST_ID="60"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "60"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 # Other options (id >= 100)
 ## MT and W2P with FTFY (en-fr)
 (
-    TEST_ID="100"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "100"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2preprocess" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
             deferred=False ftfy=True tmx=True deduped=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 ## MT and docalign / segalign threshold and deduped (en-fr)
 (
-    TEST_ID="101"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "101"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 deferred=False tmx=True deduped=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 wait

--- a/tests/run-tests-min.sh
+++ b/tests/run-tests-min.sh
@@ -70,11 +70,8 @@ rm -f "${WORK}/output_reference/run-tests-min.tgz"
 # MT (id >= 10)
 ## MT (en-fr)
 (
-    TEST_ID="10"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "10"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -82,16 +79,12 @@ rm -f "${WORK}/output_reference/run-tests-min.tgz"
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" \
             bicleanerFlavour="classic" deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 ## MT and P2T where prevertical is converted to WARC (en-fr)
 (
-    TEST_ID="11"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
-
     if [[ ! -f "${WORK}/data/prevertical/greenpeace.en.prevertical.gz" ]] || \
        [[ ! -f "${WORK}/data/prevertical/greenpeace.fr.prevertical.gz" ]]; then
         mkdir -p "${WORK}/data/tmp-w2t"
@@ -109,8 +102,8 @@ rm -f "${WORK}/output_reference/run-tests-min.tgz"
         rm -rf "${WORK}/data/tmp-w2t"
     fi
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
+    init_test "11"
+
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -118,30 +111,25 @@ rm -f "${WORK}/output_reference/run-tests-min.tgz"
             shards=1 batches=512 lang1=en lang2=fr documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" \
             deferred=True tmx=True paragraphIdentification=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 # Dictionary-based (id >= 20)
 ## Use dictionary pipeline (en-fr)
 (
-    TEST_ID="20"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "20"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" bicleaner=True bicleanerFlavour="classic" \
             bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 wait
@@ -149,11 +137,8 @@ wait
 # MT and dictionary-based (id >= 60)
 ## Combine MT and dictionary (en-fr)
 (
-    TEST_ID="60"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "60"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -161,39 +146,31 @@ wait
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" bicleaner=True bicleanerFlavour="classic" \
             bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerThreshold=0.1 deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 # Other options (id >= 100)
 ## MT and Biroamer (en-fr)
 (
-    TEST_ID="100"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "100"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
             deferred=False tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 ## 2 tests in the same scope: remove parallelism because NLTK model installation can't run in parallel (bifixer=True)
 (
     ### MT and docalign / segalign threshold and Bifixer and Bicleaner (en-fr)
-    TEST_ID="101"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "101"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -202,17 +179,13 @@ wait
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
             bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" bicleanerThreshold=0.0 \
             deferred=False bifixer=True tmx=True deduped=True biroamer=False ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 
     ### MT and docalign / segalign threshold and Bifixer and Bicleaner AI (en-fr)
-    TEST_ID="102"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+    init_test "102"
 
-    mkdir -p "${TRANSIENT_DIR}" && \
-    pushd "${TRANSIENT_DIR}" > /dev/null && \
     ${BITEXTOR} \
         --config permanentDir="${WORK}/permanent/${TEST_ID}" \
             dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -221,10 +194,9 @@ wait
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
             bicleaner=True bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerThreshold=0.0 \
             deferred=False bifixer=True tmx=True deduped=True biroamer=False ${BITEXTOR_EXTRA_ARGS} \
-        &> "${WORK}/reports/${TEST_ID}.report" && \
-    popd > /dev/null
+        &> "${WORK}/reports/${TEST_ID}.report"
 
-    annotate_and_echo_info_wrapper
+    finish_test
 ) &
 
 wait

--- a/tests/run-tests-min.sh
+++ b/tests/run-tests-min.sh
@@ -192,7 +192,7 @@ wait
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
-            bicleaner=True bicleanerModel="${BICLEANER_AI}/en-fr" bicleanerThreshold=0.0 \
+            bicleaner=True bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerThreshold=0.0 \
             deferred=False bifixer=True tmx=True deduped=True biroamer=False ${BITEXTOR_EXTRA_ARGS} \
         &> "${WORK}/reports/${TEST_ID}.report"
 

--- a/tests/run-tests-min.sh
+++ b/tests/run-tests-min.sh
@@ -192,7 +192,7 @@ wait
             warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
             documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
             sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 \
-            bicleaner=True bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerThreshold=0.0 \
+            bicleaner=True bicleanerModel="${BICLEANER_AI}/en-fr" bicleanerThreshold=0.0 \
             deferred=False bifixer=True tmx=True deduped=True biroamer=False ${BITEXTOR_EXTRA_ARGS} \
         &> "${WORK}/reports/${TEST_ID}.report"
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -519,7 +519,7 @@ tests-others()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 bicleaner=True bicleanerModelFlavour="full" \
-                bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
+                bicleanerModel="${BICLEANER_AI}/en-fr" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
                 deferred=False bifixer=True tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
             &> "${WORK}/reports/${TEST_ID}.report"
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -177,23 +177,6 @@ create-p2t-from-warc()
     fi
 }
 
-init_test()
-{
-    # Export these variables to the global scope
-    TEST_ID="$1"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
-
-    mkdir -p "${TRANSIENT_DIR}"
-    pushd "${TRANSIENT_DIR}" > /dev/null
-}
-
-finish_test()
-{
-    annotate_and_echo_info_wrapper
-
-    popd > /dev/null
-}
-
 # Specific test values
 test40_dic_hash_before=$(md5sum "${WORK}/permanent/en-fr.dic" | awk '{print $1}')
 
@@ -578,7 +561,7 @@ if [[ "$DRYRUN" == "false" ]]; then
     # Tests with id >= 40 has been executed?
     if [[ "$(( ($flags & (2**3)) >> 3 ))" == "1" ]]; then
         # Check if the dictionary has been replaced
-        if [[ ! -z "$test40_dic_hash_before" != "" ]] || [[ ! -z "$test40_dic_hash_after" ]] || \
+        if [[ -z "$test40_dic_hash_before" ]] || [[ -z "$test40_dic_hash_after" ]] || \
            [[ "$test40_dic_hash_before" != "$test40_dic_hash_after" ]]; then
             echo "Failed 40.1 (dictionary has been replaced: '$test40_dic_hash_before' -> '$test40_dic_hash_after')"
             echo "fail 40.1 \"dictionary replaced\"" >> "$FAILS"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -189,9 +189,9 @@ init_test()
 
 finish_test()
 {
-    popd > /dev/null
-
     annotate_and_echo_info_wrapper
+
+    popd > /dev/null
 }
 
 # Specific test values

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -177,16 +177,33 @@ create-p2t-from-warc()
     fi
 }
 
+init_test()
+{
+    # Export these variables to the global scope
+    TEST_ID="$1"
+    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+
+    mkdir -p "${TRANSIENT_DIR}"
+    pushd "${TRANSIENT_DIR}" > /dev/null
+}
+
+finish_test()
+{
+    popd > /dev/null
+
+    annotate_and_echo_info_wrapper
+}
+
+# Specific test values
+test40_dic_hash_before=$(md5sum "${WORK}/permanent/en-fr.dic" | awk '{print $1}')
+
 # MT (id >= 10)
 tests-mt()
 {
     ## MT (en-fr)
     (
-        TEST_ID="10"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "10"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -194,55 +211,43 @@ tests-mt()
                 documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" \
                 bicleanerFlavour="classic" deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
     ## MT (en-el)
     (
-        TEST_ID="11"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "11"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/primeminister.warc.gz']" preprocessor="warc2text" shards=1 batches=512 \
                 lang1=en lang2=el documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
     ## MT (en-ru)
     (
-        TEST_ID="12"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "12"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/kremlin.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=ru \
                 documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
     ## MT and P2T where prevertical is converted to WARC (en-fr)
     create-p2t-from-warc && \
     (
-        TEST_ID="13"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "13"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -250,10 +255,9 @@ tests-mt()
                 shards=1 batches=512 lang1=en lang2=fr documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" \
                 deferred=True tmx=True paragraphIdentification=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 }
 
@@ -262,11 +266,8 @@ tests-db()
 {
     ## Use dictionary pipeline (en-fr)
     (
-        TEST_ID="20"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "20"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -274,10 +275,9 @@ tests-db()
                 documentAligner="DIC" dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" bicleaner=True \
                 bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" bicleanerThreshold=0.1 \
                 deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 }
 
@@ -286,16 +286,13 @@ tests-gendic()
 {
     wait-if-envvar-is-true
 
-    TEST_ID="30"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
-    DIC_PATH="${WORK}/permanent/${TEST_ID}-generated-en-fr.dic"
-
-    dic_md5sum_before=$(md5sum "${WORK}/permanent/en-fr.dic" | awk '{print $1}')
-    rm -f "${DIC_PATH}"
-    mkdir -p "${TRANSIENT_DIR}"
-
     (
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
+        init_test "30"
+
+        DIC_PATH="${WORK}/permanent/${TEST_ID}-generated-en-fr.dic"
+
+        rm -f "${DIC_PATH}"
+
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -304,10 +301,9 @@ tests-gendic()
                 initCorpusTrainingPrefix="['${dn_europarl_corpus_file}/Europarl.clipped.en-fr']" bicleaner=True \
                 bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" bicleanerThreshold=0.1 \
                 deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 
     wait-if-envvar-is-true
@@ -326,16 +322,14 @@ tests-genbicleaner()
 
     wait-if-envvar-is-true
 
-    TEST_ID="40"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
-    BICLEANER_MODEL_PATH="${BICLEANER}/${TEST_ID}/generated-en-fr.yaml"
-
-    rm -f "${BICLEANER_MODEL_PATH}"
-    mkdir -p "$(dirname ${BICLEANER_MODEL_PATH})"
-    mkdir -p "${TRANSIENT_DIR}"
-
     (
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
+        init_test "40"
+
+        BICLEANER_MODEL_PATH="${BICLEANER}/${TEST_ID}/generated-en-fr.yaml"
+
+        rm -f "${BICLEANER_MODEL_PATH}"
+        mkdir -p "$(dirname ${BICLEANER_MODEL_PATH})"
+
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -349,9 +343,10 @@ tests-genbicleaner()
         popd > /dev/null
 
         annotate_and_echo_info_wrapper "reference checking skipped: non-deterministic results: https://github.com/bitextor/bicleaner/issues/72" "false"
-        dic_md5sum_after=$(md5sum "${WORK}/permanent/en-fr.dic" | awk '{print $1}')
     ) &
 
+    wait "$!" # Wait for this specific test to finish
+    test40_dic_hash_after=$(md5sum "${WORK}/permanent/en-fr.dic" | awk '{print $1}')
 
     wait-if-envvar-is-true
 }
@@ -368,19 +363,17 @@ tests-gendic-genbicleaner()
     fi
 
     wait-if-envvar-is-true
-    
-    TEST_ID="50"
-    TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
-    DIC_PATH="${WORK}/permanent/${TEST_ID}-generated-en-fr.dic"
-    BICLEANER_MODEL_PATH="${BICLEANER}/${TEST_ID}/generated-en-fr.yaml"
-
-    rm -f "${DIC_PATH}"
-    rm -f "${BICLEANER_MODEL_PATH}"
-    mkdir -p "$(dirname ${BICLEANER_MODEL_PATH})"
-    mkdir -p "${TRANSIENT_DIR}"
 
     (
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
+        init_test "50"
+
+        DIC_PATH="${WORK}/permanent/${TEST_ID}-generated-en-fr.dic"
+        BICLEANER_MODEL_PATH="${BICLEANER}/${TEST_ID}/generated-en-fr.yaml"
+
+        rm -f "${DIC_PATH}"
+        rm -f "${BICLEANER_MODEL_PATH}"
+        mkdir -p "$(dirname ${BICLEANER_MODEL_PATH})"
+
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -404,11 +397,8 @@ tests-mt-db()
 {
     ## Combine MT and dictionary (en-fr)
     (
-        TEST_ID="60"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "60"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -417,10 +407,9 @@ tests-mt-db()
                 dic="${WORK}/permanent/en-fr.dic" sentenceAligner="hunalign" bicleaner=True \
                 bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" bicleanerThreshold=0.1 \
                 deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 }
 
@@ -439,70 +428,55 @@ tests-neural()
 
     ## Neural pipeline (en-fr)
     (
-        TEST_ID="70"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "70"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="NDA" sentenceAligner="vecalign" bicleaner=True bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" \
                 bicleanerFlavour="classic" deferred=False tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 
     wait-if-envvar-is-true
 
     ## NDA and hunalign (en-el)
     (
-        TEST_ID="71"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "71"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/primeminister.warc.gz']" preprocessor="warc2text" shards=1 batches=512 \
                 lang1=en lang2=el documentAligner="NDA" dic="${WORK}/permanent/en-el.dic" sentenceAligner="hunalign" \
                 deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 
     ## Neural pipeline and deferred (en-ru)
     (
-        TEST_ID="72"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "72"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/kremlin.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=ru \
                 documentAligner="NDA" sentenceAligner="vecalign" deferred=True tmx=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 
     ## Neural pipeline and P2T and deferred and paragraph identification (en-fr)
     create-p2t-from-warc && \
     (
-        TEST_ID="73"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "73"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -510,10 +484,9 @@ tests-neural()
                 shards=1 batches=512 lang1=en lang2=fr documentAligner="NDA" sentenceAligner="vecalign" bicleaner=True \
                 bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" \
                 deferred=True tmx=True paragraphIdentification=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 }
 
@@ -522,30 +495,23 @@ tests-others()
 {
     ## MT and Biroamer (en-fr)
     (
-        TEST_ID="100"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "100"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
                 warcs="['${WORK}/data/warc/kremlin.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=ru \
                 documentAligner="externalMT" alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" sentenceAligner="bleualign" \
                 deferred=False tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
     ## 2 tests in the same scope: remove parallelism because NLTK model installation can't run in parallel (bifixer=True)
     (
         ### MT and docalign / segalign threshold and Bifixer and Bicleaner (en-fr)
-        TEST_ID="101"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "101"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -554,17 +520,13 @@ tests-others()
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 bicleaner=True \
                 bicleanerModel="${BICLEANER}/en-fr/en-fr.yaml" bicleanerFlavour="classic" bicleanerThreshold=0.0 \
                 deferred=False bifixer=True tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
 
         ### MT and docalign / segalign threshold and Bifixer and Bicleaner AI (en-fr)
-        TEST_ID="102"
-        TRANSIENT_DIR="${WORK}/transient/${TEST_ID}"
+        init_test "102"
 
-        mkdir -p "${TRANSIENT_DIR}" && \
-        pushd "${TRANSIENT_DIR}" > /dev/null && \
         ${BITEXTOR} \
             --config permanentDir="${WORK}/permanent/${TEST_ID}" \
                 dataDir="${WORK}/data/${TEST_ID}" transientDir="${TRANSIENT_DIR}" \
@@ -573,16 +535,15 @@ tests-others()
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 bicleaner=True bicleanerModelFlavour="full" \
                 bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
                 deferred=False bifixer=True tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
-            &> "${WORK}/reports/${TEST_ID}.report" && \
-        popd > /dev/null
+            &> "${WORK}/reports/${TEST_ID}.report"
 
-        annotate_and_echo_info_wrapper
+        finish_test
     ) &
 }
 
 run-tests()
 {
-    flags="$1"
+    flags="$1" # Export variable to global scope
 
     if [[ "$(echo $flags | grep ^0x)" == "" ]]; then
         flags=$(printf '%x\n' "$1")
@@ -613,11 +574,18 @@ run-tests "$FLAGS"
 wait
 
 # Post checking
-if [ $DRYRUN = false ] && [[ "$(( ($flags & (2**3)) >> 3 ))" == "1" ]] && [[ "$dic_md5sum_before" != "" ]] && [[ "$dic_md5sum_after" != "" ]] && [[ "$dic_md5sum_before" != "$dic_md5sum_after" ]]; then
-    echo "Failed 40.1 (dictionary has been replaced ($dic_md5sum_before -> $dic_md5sum_after), what is not the expected)"
-    echo "fail 40.1 \"dictionary replaced\"" >> "$FAILS"
-elif [ $DRYRUN = false ] && [[ "$(( ($flags & (2**3)) >> 3 ))" == "1" ]]; then
-    echo "Ok 40.1"
+if [[ "$DRYRUN" == "false" ]]; then
+    # Tests with id >= 40 has been executed?
+    if [[ "$(( ($flags & (2**3)) >> 3 ))" == "1" ]]; then
+        # Check if the dictionary has been replaced
+        if [[ ! -z "$test40_dic_hash_before" != "" ]] || [[ ! -z "$test40_dic_hash_after" ]] || \
+           [[ "$test40_dic_hash_before" != "$test40_dic_hash_after" ]]; then
+            echo "Failed 40.1 (dictionary has been replaced: '$test40_dic_hash_before' -> '$test40_dic_hash_after')"
+            echo "fail 40.1 \"dictionary replaced\"" >> "$FAILS"
+        else
+            echo "Ok 40.1"
+        fi
+    fi
 fi
 
 # Get hashes from all files

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -300,6 +300,9 @@ tests-genbicleaner()
         for TEST_ID in $(echo "40"); do
             annotate_and_echo_info_wrapper "skipped test: very time-consuming"
         done
+
+        test40_dic_hash_after="$test40_dic_hash_before"
+
         return
     fi
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -519,7 +519,7 @@ tests-others()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 bicleaner=True bicleanerModelFlavour="full" \
-                bicleanerModel="${BICLEANER_AI}/en-fr" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
+                bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
                 deferred=False bifixer=True tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
             &> "${WORK}/reports/${TEST_ID}.report"
 


### PR DESCRIPTION
Changes:
- GHA scripts:
  - Minor fixes.
  - New workflow which builds a docker image and runs `run-tests-min.sh` using the built image.
  - Docker GHA script now can be configured for pulling and image from Docker Hub or build an image for running the intensive tests. By default, it builds an image like conda GHA script when running intensive tests.
- Conda build replacement of `boost` dependency in order to use conda-forge channel instead of defaults.
- Tests:
  - Refactoring.
  - Fix test 40.1 in `run-tests.sh`.

Something I think it should be done in order to accept (if not rejected) this PR, is to merge using [squash](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits) method. I think this should the the followed strategy because I used many commits just for testing purposes of the CI. If we merge using the squash strategy, the history of the master branch will not be dirty for these commits I mentioned, and the changes are not many in my opinion for consider keeping all the commits because of the history, so this might be a good option.