### PR TITLE
Add fastspell apt dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get -y install openjdk-8-jdk poppler-utils
 # biroamer
 RUN /bin/echo -e "${RED}Installing biroamer apt dependencies${NC}"
 RUN apt-get -y install libgoogle-perftools-dev libsparsehash-dev
+# fastspell
+RUN /bin/echo -e "${RED}Installing fastspell apt dependencies${NC}"
+RUN apt-get -y install hunspell-af hunspell-bg hunspell-bs hunspell-ca hunspell-cs hunspell-da hunspell-es hunspell-gl hunspell-hr hunspell-nl hunspell-no hunspell-pt-pt hunspell-sk hunspell-sl hunspell-sr
+
 
 # random utilities:
 # not necessary for bitextor, but users might find this useful:


### PR DESCRIPTION
This branch contains a few apt dependencies needed for fastspell in the Dockerfile, as the current image doesn't work for some languages.