### PR TITLE
Bitextor argument to pass extra arguments to Bicleaner(-AI)

### DIFF
--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -243,6 +243,7 @@ BICLEANER_TRAINING_CORPUS_PREFIX = return_dict_value_if_key(config, "bicleanerPa
 BICLEANER_AI_MONO_CORPUS_PREFIX = return_dict_value_if_key(config, "bicleanerMonoCorpusPrefix", [])
 BICLEANER_AI_DEV_CORPUS_PREFIX = return_dict_value_if_key(config, "bicleanerParallelCorpusDevPrefix", [])
 BICLEANER_BIN = "bicleaner-classify" if BICLEANER_FLAVOUR == "classic" else "bicleaner-ai-classify"
+BICLEANER_EXTRA_ARGS = return_dict_value_if_key(config, "bicleanerExtraArgs", "")
 
 if BICLEANER:
     is_flavour_ai = BICLEANER_FLAVOUR == "ai"
@@ -1551,7 +1552,7 @@ rule bicleaner:
         zcat {input.bifixer} \
             | {PROFILING} cache -k $text_fields {BICLEANER_BIN} $bicleaner_text_fields \
                 --header {params.tokenizer_l1} {params.tokenizer_l2} \
-                --score_only -q -p {threads} - - {input.model} \
+                {BICLEANER_EXTRA_ARGS} --score_only -q -p {threads} - - {input.model} \
             | paste <(zcat {input.bifixer}) - \
             | pigz -c > {output}
         """

--- a/bitextor/utils/args.py
+++ b/bitextor/utils/args.py
@@ -228,6 +228,7 @@ def validate_args(config):
         'bicleaner': {'type': 'boolean', 'default': False},
         'bicleanerFlavour': {'type': 'string', 'allowed': ['classic', 'ai'], 'default': 'ai'},
         'bicleanerModel': {'type': 'string', 'dependencies': {'bicleaner': True}},
+        'bicleanerExtraArgs': {'type': 'string', 'dependencies': {'bicleaner': True}},
         'bicleanerGenerateModel': {'type': 'boolean', 'default': False},
         'bicleanerThreshold': {'type': 'float'},
         'bicleanerParallelCorpusTrainingPrefix': {'type': 'list'},

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -532,7 +532,7 @@ tests-others()
                 warcs="['${WORK}/data/warc/greenpeace.warc.gz']" preprocessor="warc2text" shards=1 batches=512 lang1=en lang2=fr \
                 documentAligner="externalMT" documentAlignerThreshold=0.1 alignerCmd="bash ${DIR}/../bitextor/example/dummy-translate.sh" \
                 sentenceAligner="bleualign" sentenceAlignerThreshold=0.1 bicleaner=True \
-                bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerFlavour="ai" bicleanerThreshold=0.0 \
+                bicleanerModel="${BICLEANER_AI}/en-fr/metadata.yaml" bicleanerFlavour="ai" bicleanerExtraArgs="--disable_minimal_length"  bicleanerThreshold=0.0 \
                 deferred=False bifixer=True tmx=True deduped=True biroamer=True ${BITEXTOR_EXTRA_ARGS} \
             &> "${WORK}/reports/${TEST_ID}.report"
 


### PR DESCRIPTION
In some cases, like in new MaCoCu data releases, specific flags should be triggered on Bicleaner (or Bicleaner-AI), like `--disable_minimal_length`. To allow the Bitextor users to do that without editing code, a new flag called `--bicleanerExtraArgs` or `bicleanerExtraArgs:` in `config.yaml` is enabled.