### PR TITLE
Some fixes

### DIFF
--- a/bitextor/Snakefile
+++ b/bitextor/Snakefile
@@ -1811,16 +1811,23 @@ rule documents:
     shell:
         """
         sent_file={input.sents}
-        documents_aligned=(`echo {input.documents} | tr ", " "\n"`)
+        documents_aligned=$(echo {input.documents} | tr ", " "\n")
+        header_ok=""
 
-        for document in "$documents_aligned"
+        for document in $documents_aligned
         do
-            header=$(head -1 <(zcat $document) | tr -d '\\n')
+            header="-n" #echo flag in order to avoid the new line
+            if [[ -z "$header_ok" ]]; then
+                header=$(head -1 <(zcat $document) | tr -d '\\n')
+                header_ok="true"
+            fi
             awk -F $'\t' 'NR == FNR {{ a[$0]; next}} $1"\t"$2 in a{{print $0}}' \\
                 <(zcat $sent_file | tail -n +2 | cut -f 1,2) \\
                 <(zcat $document | tail -n +2) | \\
-                cat <(echo "$header") - | pigz -c >> {output}
+                cat <(echo "$header") - | pigz -c >> {PERMANENT}.non_deduped.gz
         done
+        zcat {PERMANENT}.non_deduped.gz | sort | uniq | pigz -c > {output}
+        rm {PERMANENT}.non_deduped.gz
         """
 
 

--- a/bitextor/utils/lett2bitextor.py
+++ b/bitextor/utils/lett2bitextor.py
@@ -26,6 +26,8 @@ from tldextract import extract
 from common import open_xz_or_gzip_or_plain
 
 def main(args):
+    sys.stdin.reconfigure(encoding='utf-8', errors="backslashreplace")
+
     lett_file = args.lett_file
     langs = args.langs
     output_prefix = args.output_prefix
@@ -39,7 +41,7 @@ def main(args):
     output_files = {}
     number_output_files_open = {}
     preprocess_files = ("text", "url", "mime", "html")
-    lett_context = gzip.open(lett_file, 'rt', errors='ignore') if lett_file != '-' else contextlib.nullcontext(enter_result=sys.stdin)
+    lett_context = gzip.open(lett_file, 'rt') if lett_file != '-' else contextlib.nullcontext(enter_result=sys.stdin)
 
     with lett_context as lett:
         for idx, line in enumerate(lett, 1):

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -146,6 +146,7 @@ annotate_and_echo_info_wrapper()
         esac
         shift
     done
+    local skip_count_nolines=$([[ "$2" != "" ]] && echo "$2" || echo "true")
 
     local status="$?"
 
@@ -155,8 +156,9 @@ annotate_and_echo_info_wrapper()
     local reference_file_nolines="$(get_nolines ${reference_file})"
 
     if [[ "$skip_reason" != "" ]]; then
-        local output_file_nolines="0"
-
+        if [[ "$skip_count_nolines" == "true" ]]; then
+            local output_file_nolines="0"
+        fi
         annotate_and_echo_info "${TEST_ID}" "${status}" "${output_file_nolines}" "${skip_reason}" "${skip_count_nolines}"
 
         return

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -146,7 +146,6 @@ annotate_and_echo_info_wrapper()
         esac
         shift
     done
-    local skip_count_nolines=$([[ "$2" != "" ]] && echo "$2" || echo "true")
 
     local status="$?"
 
@@ -156,9 +155,8 @@ annotate_and_echo_info_wrapper()
     local reference_file_nolines="$(get_nolines ${reference_file})"
 
     if [[ "$skip_reason" != "" ]]; then
-        if [[ "$skip_count_nolines" == "true" ]]; then
-            local output_file_nolines="0"
-        fi
+        local output_file_nolines="0"
+
         annotate_and_echo_info "${TEST_ID}" "${status}" "${output_file_nolines}" "${skip_reason}" "${skip_count_nolines}"
 
         return


### PR DESCRIPTION
This PR fixes some issues found with the dict-docaligner and documents output.
- The mutually linked feature is now able to recognise partial urls and remove the '\n' from some urls in the document.
- The documents output rule avoids data loss and removes duplicates.