### PR TITLE
document-aligner hashing trick

### DIFF
--- a/document-aligner/CMakeLists.txt
+++ b/document-aligner/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories(
 # kpu/preprocess dependency:
 if (NOT PREPROCESS_PATH)
     # if preprocess_path is not defined, use the one in the parent folder of document-aligner
-    set(PREPROCESS_PATH "${PROJECT_SOURCE_DIR}/../preprocess")
+    set(PREPROCESS_PATH "${PROJECT_SOURCE_DIR}/../third_party/preprocess")
 endif()
 
 if (NOT SKIP_PREPROCESS_BUILD)

--- a/document-aligner/src/document.cpp
+++ b/document-aligner/src/document.cpp
@@ -30,7 +30,7 @@ inline float tfidf(size_t tf, size_t dc, size_t df) {
  * across all documents. Only terms that are seen in this document and in the document frequency table are
  * counted. All other terms are ignored.
 */
-void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, unordered_map<NGram, size_t> const &df, unordered_set<NGram> const &max_ngram_pruned) {
+void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, HashMap<NGram, size_t> const &df, size_t max_ngram_cnt) {
 	document_ref.id = document.id;
 
 	document_ref.wordvec.clear();
@@ -44,16 +44,14 @@ void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t
 
 		float document_tfidf;
 
-		if (it == df.end()) {
-			if (max_ngram_pruned.find(entry.first) == max_ngram_pruned.end()) {
-				document_tfidf = tfidf(entry.second, document_count, 1);
-			}
-			else{
-				continue;
-			}
+		if (it == df.end()) { // unknown ngram
+			document_tfidf = tfidf(entry.second, document_count, 1);
 		}
-		else {
-			document_tfidf = tfidf(entry.second, document_count, it->second);
+		// else if (*it > max_ngram_cnt) { // Very well known ngram, like stop-word
+		// 	continue;
+		// }
+		else { // Regular ngram
+			document_tfidf = tfidf(entry.second, document_count, *it);
 
 			document_ref.wordvec.push_back(WordScore{
 					.hash = entry.first,

--- a/document-aligner/src/document.cpp
+++ b/document-aligner/src/document.cpp
@@ -39,25 +39,12 @@ void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t
 	float total_tfidf_l2 = 0;
 
 	for (auto const &entry : document.vocab) {
-		// How often does the term occur in the whole dataset?
-		auto it = df.find(entry.first);
+		float document_tfidf = tfidf(entry.second, document_count, std::max(df[entry.first], 1ul));
 
-		float document_tfidf;
-
-		if (it == df.end()) { // unknown ngram
-			document_tfidf = tfidf(entry.second, document_count, 1);
-		}
-		// else if (*it > max_ngram_cnt) { // Very well known ngram, like stop-word
-		// 	continue;
-		// }
-		else { // Regular ngram
-			document_tfidf = tfidf(entry.second, document_count, *it);
-
-			document_ref.wordvec.push_back(WordScore{
-					.hash = entry.first,
-					.tfidf = document_tfidf
-			});
-		}
+		document_ref.wordvec.push_back(WordScore{
+				.hash = entry.first,
+				.tfidf = document_tfidf
+		});
 		
 		// Keep track of the squared sum of all values for L2 normalisation
 		total_tfidf_l2 += document_tfidf * document_tfidf;

--- a/document-aligner/src/document.h
+++ b/document-aligner/src/document.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "util/string_piece.hh"
 #include "ngram.h"
+#include "hashmap.h"
 #include <istream>
 #include <unordered_map>
 #include <unordered_set>
@@ -32,6 +33,6 @@ struct DocumentRef {
 // Assumes base64 encoded still.
 void ReadDocument(const util::StringPiece &encoded, Document &to, size_t ngram_size);
 
-void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, std::unordered_map<NGram, size_t> const &df, std::unordered_set<NGram> const &max_ngram_pruned);
+void calculate_tfidf(Document const &document, DocumentRef &document_ref, size_t document_count, HashMap<NGram, size_t> const &df, size_t max_ngram_cnt);
 
 } // namespace bitextor

--- a/document-aligner/src/hashmap.h
+++ b/document-aligner/src/hashmap.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <ostream>
+#include <stdexcept>
+
+namespace bitextor {
+
+template <typename K, typename T>
+class HashMap {
+	std::vector<T> backing_;
+
+	using const_iterator = typename std::vector<T>::const_iterator;
+
+public:
+	HashMap(size_t size)
+	: backing_(size, 0) {
+		//
+	}
+
+	T &operator[](K const &key) {
+		return backing_[std::hash<K>{}(key) % backing_.size()];
+	}
+
+	const_iterator find(K const &key) const {
+		return backing_.begin() + (std::hash<K>{}(key) % backing_.size());
+	}
+
+	const_iterator end() const {
+		return backing_.end();
+	}
+
+	void add(HashMap const &other, float alpha = 1.0f) {
+		if (backing_.size() != other.backing_.size())
+			throw std::logic_error("HashMap::add can only add hashmaps of the same size");
+
+		for (size_t i = 0; i < backing_.size(); ++i)
+			backing_[i] += other.backing_[i] * alpha;
+	}
+};
+
+} // namespace bitextor

--- a/document-aligner/src/hashmap.h
+++ b/document-aligner/src/hashmap.h
@@ -23,12 +23,8 @@ public:
 		return backing_[std::hash<K>{}(key) % backing_.size()];
 	}
 
-	const_iterator find(K const &key) const {
-		return backing_.begin() + (std::hash<K>{}(key) % backing_.size());
-	}
-
-	const_iterator end() const {
-		return backing_.end();
+	T const &operator[](K const &key) const {
+		return backing_[std::hash<K>{}(key) % backing_.size()];
 	}
 
 	void add(HashMap const &other, float alpha = 1.0f) {


### PR DESCRIPTION
If we assume that collisions aren't that much of a problem because most entries are just 1 or 2 anyway, could we get away with a truncated fixed size hashtable?